### PR TITLE
token expiry as date

### DIFF
--- a/components/Login/Login.tsx
+++ b/components/Login/Login.tsx
@@ -57,28 +57,9 @@ export default function Login({
         const now = Date.now();
         let expiresAtMs: number = 0;
 
-        if (response.expiresAt || response.accessTokenExpiresIn) {
-          // Parse server expiry (could be timestamp or relative time)
-          if (response.expiresAt) {
-            expiresAtMs = new Date(response.expiresAt).getTime();
-          } else if (response.accessTokenExpiresIn) {
-            // Parse relative time like "24h", "7d"
-            const match =
-              response.accessTokenExpiresIn?.match(/(\d+)([dhmwy])/);
-            if (match) {
-              const value = Number.parseInt(match?.[1] ?? '', 10);
-              const unit = match?.[2];
-              const multipliers = {
-                h: 3_600_000,
-                d: 86_400_000,
-                w: 604_800_000,
-                m: 2_629_746_000,
-                y: 31_536_000_000,
-              };
-              expiresAtMs =
-                now + value * multipliers[unit as keyof typeof multipliers];
-            }
-          }
+        if (response.accessTokenExpiresAt) {
+          // Parse server expiry (ISO date string)
+          expiresAtMs = new Date(response.accessTokenExpiresAt).getTime();
         }
 
         const maxAge =
@@ -90,7 +71,7 @@ export default function Login({
         await setAuthCookies({
           token: response.accessToken,
           refreshToken: response.refreshToken,
-          expiresAt: response.expiresAt,
+          expiresAt: response.accessTokenExpiresAt,
           expiresAtMs,
           userId: response.user.id,
           maxAge,

--- a/lib/requests.ts
+++ b/lib/requests.ts
@@ -242,34 +242,9 @@ export const AuthService = {
     const token = authHeaders();
     if (!token.Authorization) throw new Error('Token not found');
 
-    const raw = getCookie('token');
-    if (!raw || typeof raw !== 'string') throw new Error('Token not found');
-
-    let refreshTokenValue: string | undefined;
-    try {
-      const parsed = JSON.parse(raw);
-      if (isTokenCookie(parsed)) {
-        refreshTokenValue = parsed.refreshToken;
-      }
-    } catch {
-      // Try to decode and parse as fallback
-      try {
-        const decoded = decodeURIComponent(raw);
-        const fallbackParsed = JSON.parse(decoded);
-        if (isTokenCookie(fallbackParsed)) {
-          refreshTokenValue = fallbackParsed.refreshToken;
-        }
-      } catch {
-        // Leave undefined if all parsing attempts fail
-      }
-    }
-
-    if (!refreshTokenValue) throw new Error('Refresh token not found');
-
     try {
       const result = await client
         .post(API_CONFIG.AUTH.REFRESH, {
-          json: { refreshToken: refreshTokenValue },
           headers: token,
         })
         .json<RefreshTokenResponse>();

--- a/types/ResponseInterfaces.ts
+++ b/types/ResponseInterfaces.ts
@@ -25,8 +25,8 @@ export interface UserPayload {
   id: string;
   email: string;
   username: string;
-  firstName: string;
-  lastName: string;
+  firstName?: string;
+  lastName?: string;
   phoneNumber?: string;
 }
 
@@ -45,8 +45,8 @@ export interface AuthTokens {
 export interface AuthResponseDto {
   accessToken: string;
   refreshToken: string;
-  accessTokenExpiresIn: string; // "24h"
-  refreshTokenExpiresIn: string; // "7d"
+  accessTokenExpiresAt: string;
+  refreshTokenExpiresAt: string;
   user: {
     id: string;
     username: string;
@@ -60,7 +60,6 @@ export interface AuthResponseDto {
 export interface RegistrationResponseDto {
   message: string;
   email: string;
-  requiresEmailConfirmation: boolean;
 }
 
 export interface LoginDto {
@@ -72,13 +71,15 @@ export interface RefreshTokenDto {
   refreshToken: string;
 }
 
+export interface ResendConfirmationDto {
+  email: string;
+}
+
 export interface AuthResponse extends BaseResponse {
   accessToken: string;
   refreshToken: string;
-  accessTokenExpiresIn: string;
-  refreshTokenExpiresIn: string;
-  expiresAt?: string;
-  expiresAt_ts?: number;
+  accessTokenExpiresAt: string;
+  refreshTokenExpiresAt: string;
   user: UserPayload;
 }
 
@@ -207,9 +208,7 @@ export interface EmailAlreadyConfirmedResponse extends BaseErrorResponse {
 
 export interface HealthResponse {
   status: 'ok' | 'error';
-  timestamp: string;
-  uptime: number;
-  version?: string;
+  details?: Record<string, unknown>;
 }
 
 // TODO: Consider extending these type aliases to unions for error variants
@@ -241,8 +240,8 @@ export enum HttpStatus {
 export interface TokenExpiryInfo {
   accessToken: string;
   refreshToken: string;
-  accessTokenExpiresIn: string;
-  refreshTokenExpiresIn: string;
+  accessTokenExpiresAt: string;
+  refreshTokenExpiresAt: string;
 }
 
 export enum ErrorType {


### PR DESCRIPTION
### TL;DR

Updated authentication flow to use ISO date strings for token expiration instead of relative time formats.

### What changed?

- Simplified token expiration handling by using `accessTokenExpiresAt` instead of parsing relative time formats like "24h" or "7d"
- Removed the complex refresh token extraction logic from cookies in the `AuthService`
- Updated the `AuthResponseDto` and related interfaces to use explicit expiration timestamps (`accessTokenExpiresAt`, `refreshTokenExpiresAt`) instead of relative time formats
- Made `firstName` and `lastName` optional in the `UserPayload` interface
- Removed `requiresEmailConfirmation` from `RegistrationResponseDto`
- Added `ResendConfirmationDto` interface
- Simplified the `HealthResponse` interface to only require status and optional details

### Why make this change?

This change standardizes the way we handle token expiration by using ISO date strings instead of relative time formats. This approach is more reliable and easier to maintain as it eliminates the need for complex parsing logic. It also aligns our client-side code with the updated API response format, ensuring compatibility with the backend services.