### PR TITLE
pkg upd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "clsx": "^2.1.1",
         "cookies-next": "^6.1.1",
         "ky": "^1.14.3",
-        "lucide-react": "^0.569.0",
+        "lucide-react": "^0.574.0",
         "negotiator": "^1.0.0",
         "next": "16.1.6",
         "next-themes": "^0.4.6",
@@ -6786,7 +6786,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.569.0",
+      "version": "0.574.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.574.0.tgz",
+      "integrity": "sha512-dJ8xb5juiZVIbdSn3HTyHsjjIwUwZ4FNwV0RtYDScOyySOeie1oXZTymST6YPJ4Qwt3Po8g4quhYl4OxtACiuQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"


### PR DESCRIPTION
### TL;DR

Upgraded lucide-react from version 0.569.0 to 0.574.0.

### What changed?

This PR updates the lucide-react package to the latest version (0.574.0) from the previous version (0.569.0). The package-lock.json has been updated with the new version, including the resolved URL and integrity hash.

### Why make this change?

Keeping dependencies up-to-date ensures we have the latest features, bug fixes, and security patches. This minor version update of lucide-react likely includes new icons or improvements to existing ones that will benefit our application.