### PR TITLE
assitant fix

### DIFF
--- a/components/app/business-accountant/BusinessAccountant.tsx
+++ b/components/app/business-accountant/BusinessAccountant.tsx
@@ -18,6 +18,7 @@ import {
   XCircle,
   PlayCircle,
   Calendar as CalendarIcon,
+  Ban,
 } from 'lucide-react';
 import { type Locale } from '@/i18n-config';
 import { type Dictionary } from '@/get-dictionary';
@@ -73,7 +74,7 @@ import { Progress } from '@/components/ui/progress';
 import { toast } from 'sonner';
 
 import type {
-  AccountingJobStatus,
+  AccountantJobStatus,
   CreateAccountingJobInput,
 } from '@/types/services';
 
@@ -83,12 +84,12 @@ interface BusinessAccountantProps {
   dictionary: Dictionary;
 }
 
-const statusIcons: Record<AccountingJobStatus, typeof Clock> = {
+const statusIcons: Record<AccountantJobStatus, typeof Clock> = {
   pending: Clock,
   processing: Loader2,
   completed: CheckCircle2,
   failed: XCircle,
-  cancelled: XCircle,
+  cancelled: Ban,
 };
 
 export default function BusinessAccountant({
@@ -121,7 +122,7 @@ export default function BusinessAccountant({
     refetch: refetchJobs,
   } = useQuery({
     queryKey: ['accountant-jobs', businessId],
-    queryFn: () => AccountantService.listJobs(businessId),
+    queryFn: () => AccountantService.listJobs({ businessId }),
     enabled: !!businessId,
     staleTime: 30 * 1000,
     retry: 1,
@@ -129,22 +130,27 @@ export default function BusinessAccountant({
 
   const { data: jobResults, isLoading: jobResultsLoading } = useQuery({
     queryKey: ['accountant-job-results', businessId, selectedJobId],
-    queryFn: selectedJobId
-      ? () => AccountantService.getJobResults(businessId, selectedJobId)
-      : skipToken,
+    queryFn:
+      selectedJobId && businessId
+        ? () =>
+            AccountantService.getJobResults(
+              { taskId: selectedJobId },
+              { businessId }
+            )
+        : skipToken,
   });
 
   const { data: taxData, isLoading: taxLoading } = useQuery({
     queryKey: ['accountant-taxes', businessId, selectedYear],
-    queryFn: () => AccountantService.getTaxes(businessId, selectedYear),
+    queryFn: () =>
+      AccountantService.getTaxes({ businessId, year: selectedYear }),
     enabled: !!businessId && !!selectedYear,
   });
 
   const { data: healthData } = useQuery({
-    queryKey: ['accountant-health', businessId],
-    queryFn: () => AccountantService.health(businessId),
+    queryKey: ['accountant-health'],
+    queryFn: () => AccountantService.health(),
     retry: 1,
-    enabled: !!businessId,
   });
 
   const createJobMutation = useMutation({
@@ -165,12 +171,9 @@ export default function BusinessAccountant({
 
   const cancelJobMutation = useMutation({
     mutationFn: ({ taskId }: { taskId: string }) =>
-      AccountantService.cancelJob(businessId, taskId),
+      AccountantService.cancelJob({ taskId }, { businessId }),
     onSuccess: (data) => {
-      // API returns a wrapped CancelJobWrapper; unwrap message
-      const message =
-        (data as { data?: { message?: string } })?.data?.message ||
-        t.jobCancelled;
+      const message = data?.result?.message || t.jobCancelled;
       toast.success(message);
       queryClient.invalidateQueries({
         queryKey: ['accountant-jobs', businessId],
@@ -179,6 +182,22 @@ export default function BusinessAccountant({
     onError: (error: unknown) => {
       const err = error as Error;
       toast.error(err.message || t.cancelJobError);
+    },
+  });
+
+  const calculateTaxesMutation = useMutation({
+    mutationFn: () =>
+      AccountantService.calculateTaxes({ businessId, year: selectedYear }),
+    onSuccess: (data) => {
+      const message = data.result.message ?? t.taxesCalculated;
+      toast.success(message);
+      queryClient.invalidateQueries({
+        queryKey: ['accountant-taxes', businessId, selectedYear],
+      });
+    },
+    onError: (error: unknown) => {
+      const err = error as Error;
+      toast.error(err.message || t.calculateTaxesError);
     },
   });
 
@@ -201,20 +220,15 @@ export default function BusinessAccountant({
   };
 
   const jobs = useMemo(() => {
-    const jobList = jobsData?.data || [];
-    return jobList;
+    return jobsData?.jobs ?? [];
   }, [jobsData]);
 
-  const taxSummary = useMemo(() => taxData?.data ?? undefined, [taxData]);
-  // getJobResults now returns a wrapped response; unwrap here for consumers
-  const selectedJobResults = useMemo(
-    () => jobResults?.data ?? undefined,
-    [jobResults]
-  );
+  const taxSummary = useMemo(() => taxData?.taxes, [taxData]);
+  const selectedJobResults = useMemo(() => jobResults?.results, [jobResults]);
   const isServiceAvailable =
     healthData?.success && healthData?.status === 'available';
 
-  const renderStatusBadge = (status: AccountingJobStatus) => {
+  const renderStatusBadge = (status: AccountantJobStatus) => {
     const Icon = statusIcons[status] || Clock; // Fallback to Clock for unknown statuses
     return (
       <Badge
@@ -368,22 +382,21 @@ export default function BusinessAccountant({
                       .map((job) => (
                         <Button
                           variant="ghost"
-                          key={job.task_id}
+                          key={job.taskId}
                           className="hover:bg-muted flex h-auto w-full cursor-pointer items-center justify-between rounded-lg border p-4 text-left transition-colors"
                           onClick={() => {
-                            setSelectedJobId(job.task_id);
+                            setSelectedJobId(job.taskId);
                             setActiveTab('overview');
                           }}
                         >
                           <div className="space-y-1">
                             <p className="font-medium">
-                              {formatDate(job.period_start, lang)}
+                              {formatDate(job.periodStart, lang)}
                               {' - '}
-                              {formatDate(job.period_end, lang)}
+                              {formatDate(job.periodEnd, lang)}
                             </p>
                             <p className="text-muted-foreground text-sm">
-                              {formatDate(job.period_start, lang)} ·{' '}
-                              {job.status}
+                              {t.status[job.status]}
                             </p>
                           </div>
                           <ChevronRight className="text-muted-foreground h-5 w-5" />
@@ -431,81 +444,85 @@ export default function BusinessAccountant({
                   <p>{t.noJobs}</p>
                 </div>
               ) : (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>{t.periodColumn}</TableHead>
-                      <TableHead>{t.statusColumn}</TableHead>
-                      <TableHead>{t.progressColumn}</TableHead>
-                      <TableHead>{t.entriesColumn}</TableHead>
-                      <TableHead className="text-right">
-                        {t.actionsColumn}
-                      </TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {jobs.map((job) => (
-                      <TableRow key={job.task_id}>
-                        <TableCell>
-                          <div className="space-y-1">
-                            <p className="font-medium">
-                              {formatDate(job.period_start, lang)} -{' '}
-                              {formatDate(job.period_end, lang)}
-                            </p>
-                            <p className="text-muted-foreground text-xs">
-                              {formatDate(job.period_start, lang)}
-                            </p>
-                          </div>
-                        </TableCell>
-                        <TableCell>{renderStatusBadge(job.status)}</TableCell>
-                        <TableCell>
-                          <div className="w-full max-w-[100px]">
-                            <Progress
-                              value={job.progress_percent ?? 0}
-                              className="h-2"
-                            />
-                            <span className="text-muted-foreground text-xs">
-                              {job.progress_percent ?? 0}%
-                            </span>
-                          </div>
-                        </TableCell>
-                        <TableCell>-</TableCell>
-                        <TableCell className="text-right">
-                          <div className="flex items-center justify-end gap-2">
-                            {job.status === 'pending' ||
-                            job.status === 'processing' ? (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                disabled={cancelJobMutation.isPending}
-                                onClick={() =>
-                                  cancelJobMutation.mutate({
-                                    taskId: job.task_id,
-                                  })
-                                }
-                              >
-                                {cancelJobMutation.isPending
-                                  ? t.cancelling
-                                  : t.cancel}
-                              </Button>
-                            ) : job.status === 'completed' ? (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => {
-                                  setSelectedJobId(job.task_id);
-                                  setActiveTab('overview');
-                                }}
-                              >
-                                {t.viewResults}
-                              </Button>
-                            ) : undefined}
-                          </div>
-                        </TableCell>
+                <div className="rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>{t.periodColumn}</TableHead>
+                        <TableHead>{t.statusColumn}</TableHead>
+                        <TableHead>{t.progressColumn}</TableHead>
+                        <TableHead>{t.entriesColumn}</TableHead>
+                        <TableHead className="text-right">
+                          {t.actionsColumn}
+                        </TableHead>
                       </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
+                    </TableHeader>
+                    <TableBody>
+                      {jobs.map((job) => (
+                        <TableRow key={job.taskId}>
+                          <TableCell>
+                            <div className="space-y-1">
+                              <p className="font-medium">
+                                {formatDate(job.periodStart, lang)} -{' '}
+                                {formatDate(job.periodEnd, lang)}
+                              </p>
+                              <p className="text-muted-foreground text-xs">
+                                {job.startedAt
+                                  ? formatDate(job.startedAt, lang)
+                                  : '-'}
+                              </p>
+                            </div>
+                          </TableCell>
+                          <TableCell>{renderStatusBadge(job.status)}</TableCell>
+                          <TableCell>
+                            <div className="w-full max-w-[100px]">
+                              <Progress
+                                value={job.progressPercent ?? 0}
+                                className="h-2"
+                              />
+                              <span className="text-muted-foreground text-xs">
+                                {job.progressPercent ?? 0}%
+                              </span>
+                            </div>
+                          </TableCell>
+                          <TableCell>{job.journalEntriesCount}</TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex items-center justify-end gap-2">
+                              {job.status === 'pending' ||
+                              job.status === 'processing' ? (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  disabled={cancelJobMutation.isPending}
+                                  onClick={() =>
+                                    cancelJobMutation.mutate({
+                                      taskId: job.taskId,
+                                    })
+                                  }
+                                >
+                                  {cancelJobMutation.isPending
+                                    ? t.cancelling
+                                    : t.cancel}
+                                </Button>
+                              ) : job.status === 'completed' ? (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => {
+                                    setSelectedJobId(job.taskId);
+                                    setActiveTab('overview');
+                                  }}
+                                >
+                                  {t.viewResults}
+                                </Button>
+                              ) : undefined}
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
               )}
             </CardContent>
           </Card>
@@ -540,7 +557,9 @@ export default function BusinessAccountant({
               t={t}
               lang={lang}
               isLoading={taxLoading}
+              isCalculating={calculateTaxesMutation.isPending}
               formatCurrency={formatCurrency}
+              onCalculateTaxes={() => calculateTaxesMutation.mutate()}
             />
           </div>
         </TabsContent>

--- a/components/app/business-accountant/JobResultsView.tsx
+++ b/components/app/business-accountant/JobResultsView.tsx
@@ -3,9 +3,13 @@
 import {
   Calculator,
   CheckCircle2,
+  CreditCard,
   DollarSign,
+  FileText,
+  Receipt,
   TrendingDown,
   TrendingUp,
+  Wallet,
 } from 'lucide-react';
 import { type Locale } from '@/i18n-config';
 import { type Dictionary } from '@/get-dictionary';
@@ -27,18 +31,10 @@ import {
   TableHead,
   TableCell,
 } from '@/components/ui/table';
-import type {
-  GetAccountingJobResultsResponse,
-  GetAccountingJobResultsWrapper,
-} from '@/types/services';
+import type { GetJobResultsResponseDto } from '@/types/services';
 
 interface JobResultsViewProps {
-  // Accept either the wrapped API response (`{ success, data }`) or the
-  // unwrapped `GetAccountingJobResultsResponse` and normalize below.
-  results:
-    | GetAccountingJobResultsResponse
-    | GetAccountingJobResultsWrapper
-    | undefined;
+  results: GetJobResultsResponseDto['results'] | undefined;
   t: Dictionary['pages']['businessAccountant'];
   lang: Locale;
   formatCurrency: (amount: number, currency?: string) => string;
@@ -65,44 +61,45 @@ export function JobResultsView({
       </Card>
     );
 
-  const normalized: GetAccountingJobResultsResponse =
-    results &&
-    'data' in results &&
-    (results as GetAccountingJobResultsWrapper).data
-      ? (results as GetAccountingJobResultsWrapper).data
-      : (results as GetAccountingJobResultsResponse);
-
   const {
-    task_id,
-    total_revenue,
-    total_expenses,
-    net_profit,
-    ai_insights,
+    taskId,
+    periodStart,
+    periodEnd,
+    totalRevenue,
+    totalExpenses,
+    netProfit,
+    grossProfit,
+    accountsReceivable,
+    accountsPayable,
+    cashPosition,
+    taxCalculations,
+    aiInsights,
     recommendations,
-  } = normalized;
-
-  const {
-    gross_profit,
-    tax_calculations,
-    anomalies_detected,
+    anomaliesDetected,
     reports,
-    journal_entries_preview,
-    total_journal_entries,
-    completed_at,
-  } = normalized;
+    journalEntriesPreview,
+    totalJournalEntries,
+  } = results;
 
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-xl font-semibold">{t.jobResultsTitle}</h2>
-          <p className="text-muted-foreground font-mono text-sm">{task_id}</p>
+          <p className="text-muted-foreground font-mono text-sm">{taskId}</p>
+          {(periodStart || periodEnd) && (
+            <p className="text-muted-foreground text-sm">
+              {periodStart && formatDate(periodStart, lang)}
+              {periodStart && periodEnd && ' - '}
+              {periodEnd && formatDate(periodEnd, lang)}
+            </p>
+          )}
         </div>
         <Button variant="outline" size="sm" onClick={onClose}>
           {t.close}
         </Button>
       </div>
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardHeader className="pb-2">
             <CardDescription className="flex items-center gap-1">
@@ -110,7 +107,7 @@ export function JobResultsView({
               {t.totalRevenue}
             </CardDescription>
             <CardTitle className="text-2xl">
-              {formatCurrency(total_revenue ?? 0)}
+              {formatCurrency(totalRevenue ?? 0)}
             </CardTitle>
           </CardHeader>
         </Card>
@@ -121,7 +118,7 @@ export function JobResultsView({
               {t.grossProfit}
             </CardDescription>
             <CardTitle className="text-2xl">
-              {formatCurrency(gross_profit ?? 0)}
+              {formatCurrency(grossProfit ?? 0)}
             </CardTitle>
           </CardHeader>
         </Card>
@@ -132,7 +129,7 @@ export function JobResultsView({
               {t.totalExpenses}
             </CardDescription>
             <CardTitle className="text-2xl">
-              {formatCurrency(total_expenses ?? 0)}
+              {formatCurrency(totalExpenses ?? 0)}
             </CardTitle>
           </CardHeader>
         </Card>
@@ -145,45 +142,73 @@ export function JobResultsView({
             <CardTitle
               className={cn(
                 'text-2xl',
-                (net_profit ?? 0) >= 0 ? 'text-green-600' : 'text-red-600'
+                (netProfit ?? 0) >= 0 ? 'text-green-600' : 'text-red-600'
               )}
             >
-              {formatCurrency(net_profit ?? 0)}
+              {formatCurrency(netProfit ?? 0)}
             </CardTitle>
           </CardHeader>
         </Card>
       </div>
-      {/* Additional summaries */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardDescription>{t.totalJournalEntries}</CardDescription>
+          <CardTitle className="text-2xl">
+            {String(totalJournalEntries ?? 0)}
+          </CardTitle>
+        </CardHeader>
+      </Card>
+
+      {(accountsReceivable !== undefined ||
+        accountsPayable !== undefined ||
+        cashPosition !== undefined) && (
+        <div className="grid gap-4 sm:grid-cols-3">
+          {accountsReceivable !== undefined && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription className="flex items-center gap-1">
+                  <Receipt className="h-4 w-4 text-orange-500" />
+                  {t.accountsReceivable}
+                </CardDescription>
+                <CardTitle className="text-2xl">
+                  {formatCurrency(accountsReceivable)}
+                </CardTitle>
+              </CardHeader>
+            </Card>
+          )}
+          {accountsPayable !== undefined && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription className="flex items-center gap-1">
+                  <CreditCard className="h-4 w-4 text-purple-500" />
+                  {t.accountsPayable}
+                </CardDescription>
+                <CardTitle className="text-2xl">
+                  {formatCurrency(accountsPayable)}
+                </CardTitle>
+              </CardHeader>
+            </Card>
+          )}
+          {cashPosition !== undefined && (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardDescription className="flex items-center gap-1">
+                  <Wallet className="h-4 w-4 text-emerald-500" />
+                  {t.cashPosition}
+                </CardDescription>
+                <CardTitle className="text-2xl">
+                  {formatCurrency(cashPosition)}
+                </CardTitle>
+              </CardHeader>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {aiInsights && (
         <Card>
-          <CardHeader>
-            <CardDescription>{t.totalJournalEntries}</CardDescription>
-            <CardTitle className="text-2xl">
-              {String(total_journal_entries ?? 0)}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardDescription>{t.statusLabel}</CardDescription>
-            <CardTitle className="text-2xl">
-              {t.status[normalized.status as keyof typeof t.status] ??
-                normalized.status}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardDescription>{t.completedAt}</CardDescription>
-            <CardTitle className="text-2xl">
-              {completed_at ? formatDate(completed_at, lang) : '-'}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-      </div>
-      {ai_insights && (
-        <Card>
-          <CardHeader>
+          <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2">
               <Calculator className="h-5 w-5" />
               {t.aiInsights}
@@ -191,65 +216,77 @@ export function JobResultsView({
           </CardHeader>
           <CardContent>
             <p className="text-muted-foreground whitespace-pre-wrap">
-              {ai_insights}
+              {aiInsights}
             </p>
           </CardContent>
         </Card>
       )}
 
-      {tax_calculations && tax_calculations.length > 0 && (
+      {taxCalculations && taxCalculations.length > 0 && (
         <Card>
           <CardHeader>
             <CardTitle>{t.taxCalculations}</CardTitle>
           </CardHeader>
           <CardContent>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t.taxType}</TableHead>
-                  <TableHead>{t.jurisdiction}</TableHead>
-                  <TableHead className="text-right">{t.taxable}</TableHead>
-                  <TableHead className="text-right">{t.rate}</TableHead>
-                  <TableHead className="text-right">{t.amount}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {tax_calculations.map((tc, idx) => (
-                  <TableRow key={idx}>
-                    <TableCell>{tc.tax_type}</TableCell>
-                    <TableCell>{tc.jurisdiction}</TableCell>
-                    <TableCell className="text-right">
-                      {formatCurrency(tc.taxable_amount ?? 0)}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      {(tc.tax_rate * 100).toFixed(2)}%
-                    </TableCell>
-                    <TableCell className="text-right">
-                      {formatCurrency(tc.tax_amount ?? 0)}
-                    </TableCell>
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t.taxType}</TableHead>
+                    <TableHead>{t.jurisdiction}</TableHead>
+                    <TableHead className="text-right">{t.taxable}</TableHead>
+                    <TableHead className="text-right">{t.rate}</TableHead>
+                    <TableHead className="text-right">{t.amount}</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {taxCalculations.map((tc, idx) => (
+                    <TableRow key={idx}>
+                      <TableCell>{tc.taxType}</TableCell>
+                      <TableCell>{tc.jurisdiction}</TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(tc.taxableAmount ?? 0)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {((tc.taxRate ?? 0) * 100).toFixed(2)}%
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(tc.taxAmount ?? 0)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           </CardContent>
         </Card>
       )}
 
-      {anomalies_detected && anomalies_detected.length > 0 && (
+      {anomaliesDetected && anomaliesDetected.length > 0 && (
         <Card>
-          <CardHeader>
+          <CardHeader className="pb-3">
             <CardTitle>{t.anomalies}</CardTitle>
           </CardHeader>
           <CardContent>
-            <ul className="space-y-2">
-              {anomalies_detected.map((an, idx) => (
-                <li key={idx} className="flex flex-col">
-                  <span className="font-medium">
-                    {an.type} — {an.severity}
-                  </span>
-                  <span className="text-muted-foreground">
-                    {an.description}
-                  </span>
+            <ul className="space-y-3">
+              {anomaliesDetected.map((anomaly, idx) => (
+                <li key={idx} className="flex items-start gap-2">
+                  <span
+                    className={cn(
+                      'mt-0.5 h-2 w-2 shrink-0 rounded-full',
+                      anomaly.severity === 'high'
+                        ? 'bg-red-500'
+                        : anomaly.severity === 'medium'
+                          ? 'bg-yellow-500'
+                          : 'bg-blue-500'
+                    )}
+                  />
+                  <div>
+                    <span className="font-medium">{anomaly.type}:</span>{' '}
+                    <span className="text-muted-foreground">
+                      {anomaly.description}
+                    </span>
+                  </div>
                 </li>
               ))}
             </ul>
@@ -259,29 +296,23 @@ export function JobResultsView({
 
       {reports && reports.length > 0 && (
         <Card>
-          <CardHeader>
-            <CardTitle>{t.reports}</CardTitle>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2">
+              <FileText className="h-5 w-5" />
+              {t.reports}
+            </CardTitle>
           </CardHeader>
           <CardContent>
-            <ul className="space-y-2">
-              {reports.map((r, idx) => (
-                <li key={idx} className="flex items-center justify-between">
-                  <div>
-                    <div className="font-medium">{r.report_type}</div>
-                    <div className="text-muted-foreground text-sm">
-                      {formatDate(r.generated_at, lang)}
-                    </div>
-                  </div>
-                  {r.download_url ? (
-                    <a
-                      href={r.download_url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-primary"
-                    >
-                      {t.download}
-                    </a>
-                  ) : undefined}
+            <ul className="space-y-3">
+              {reports.map((report, idx) => (
+                <li key={idx} className="rounded-md border p-3">
+                  <p className="font-medium capitalize">
+                    {report.reportType.replaceAll('_', ' ')}
+                  </p>
+                  <p className="text-muted-foreground text-sm">
+                    {formatDate(report.periodStart, lang)} -{' '}
+                    {formatDate(report.periodEnd, lang)}
+                  </p>
                 </li>
               ))}
             </ul>
@@ -289,51 +320,65 @@ export function JobResultsView({
         </Card>
       )}
 
-      {journal_entries_preview && journal_entries_preview.length > 0 && (
+      {journalEntriesPreview && journalEntriesPreview.length > 0 && (
         <Card>
           <CardHeader>
             <CardTitle>{t.journalEntriesPreview}</CardTitle>
           </CardHeader>
           <CardContent>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t.date}</TableHead>
-                  <TableHead>{t.account}</TableHead>
-                  <TableHead className="text-right">{t.debit}</TableHead>
-                  <TableHead className="text-right">{t.credit}</TableHead>
-                  <TableHead>{t.descriptionColumn}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {journal_entries_preview.map((je, idx) => (
-                  <TableRow key={idx}>
-                    <TableCell>{formatDate(je.date, lang)}</TableCell>
-                    <TableCell>{je.account}</TableCell>
-                    <TableCell className="text-right">
-                      {formatCurrency(je.debit ?? 0)}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      {formatCurrency(je.credit ?? 0)}
-                    </TableCell>
-                    <TableCell>{je.description}</TableCell>
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t.date}</TableHead>
+                    <TableHead>{t.descriptionColumn}</TableHead>
+                    <TableHead className="text-right">{t.debit}</TableHead>
+                    <TableHead className="text-right">{t.credit}</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {journalEntriesPreview.map((je, idx) => (
+                    <TableRow key={idx}>
+                      <TableCell>
+                        {je.date ? formatDate(je.date, lang) : '-'}
+                      </TableCell>
+                      <TableCell>
+                        {je.description}
+                        {je.account && (
+                          <span className="text-muted-foreground ml-1 text-xs">
+                            ({je.account})
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {je.debit === undefined
+                          ? '-'
+                          : formatCurrency(je.debit)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {je.credit === undefined
+                          ? '-'
+                          : formatCurrency(je.credit)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           </CardContent>
         </Card>
       )}
+
       {recommendations && recommendations.length > 0 && (
         <Card>
-          <CardHeader>
+          <CardHeader className="pb-3">
             <CardTitle>{t.recommendations}</CardTitle>
           </CardHeader>
           <CardContent>
             <ul className="space-y-2">
               {recommendations.map((rec, idx) => (
                 <li key={idx} className="flex items-start gap-2">
-                  <CheckCircle2 className="mt-0.5 h-4 w-4 text-green-500" />
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-green-500" />
                   <span>{rec}</span>
                 </li>
               ))}

--- a/components/app/business-accountant/TaxSummaryView.tsx
+++ b/components/app/business-accountant/TaxSummaryView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Calculator } from 'lucide-react';
+import { Calculator, Loader2 } from 'lucide-react';
 import { type Locale } from '@/i18n-config';
 import { type Dictionary } from '@/get-dictionary';
 import { formatDate } from '@/lib/date-utils';
@@ -11,6 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   Table,
@@ -20,15 +21,16 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import type { TaxSummaryResponse, TaxSummaryWrapper } from '@/types/services';
+import type { TunisianTaxSummaryResponseDto } from '@/types/services';
 
 interface TaxSummaryViewProps {
-  // Accept either the wrapped API response or the unwrapped TaxSummaryResponse
-  taxData: TaxSummaryResponse | TaxSummaryWrapper | undefined;
+  taxData: TunisianTaxSummaryResponseDto['taxes'] | undefined;
   t: Dictionary['pages']['businessAccountant'];
   lang: Locale;
   isLoading: boolean;
+  isCalculating?: boolean;
   formatCurrency: (amount: number, currency?: string) => string;
+  onCalculateTaxes?: () => void;
 }
 
 export function TaxSummaryView({
@@ -36,7 +38,9 @@ export function TaxSummaryView({
   t,
   lang,
   isLoading,
+  isCalculating,
   formatCurrency,
+  onCalculateTaxes,
 }: TaxSummaryViewProps) {
   if (isLoading) {
     return (
@@ -56,31 +60,69 @@ export function TaxSummaryView({
         <CardContent className="py-8 text-center">
           <Calculator className="mx-auto mb-2 h-12 w-12 opacity-50" />
           <p className="text-muted-foreground">{t.noTaxData}</p>
+          {onCalculateTaxes && (
+            <Button
+              onClick={onCalculateTaxes}
+              disabled={isCalculating}
+              className="mt-4"
+            >
+              {isCalculating ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  {t.calculating}
+                </>
+              ) : (
+                <>
+                  <Calculator className="mr-2 h-4 w-4" />
+                  {t.calculateTaxes}
+                </>
+              )}
+            </Button>
+          )}
         </CardContent>
       </Card>
     );
   }
 
-  const normalized: TaxSummaryResponse =
-    taxData && 'data' in taxData && (taxData as TaxSummaryWrapper).data
-      ? (taxData as TaxSummaryWrapper).data
-      : (taxData as TaxSummaryResponse);
-
-  const currency = normalized.currency || 'TND';
-  const summary = normalized.summary || {};
-  const vatBreakdown = normalized.vat_breakdown || {};
-  const monthlyDetails = normalized.monthly_details || [];
-  const taxCalendar = normalized.tax_calendar || [];
+  const currency = taxData.currency ?? 'TND';
+  const summary = taxData.summary ?? {};
+  const vatBreakdown = taxData.vatBreakdown ?? {};
+  const monthlyDetails = taxData.monthlyDetails ?? [];
+  const taxCalendar = taxData.taxCalendar ?? [];
 
   return (
     <div className="space-y-4">
+      {/* Tax Summary Header with Recalculate */}
+      {onCalculateTaxes && (
+        <div className="flex items-center justify-end">
+          <Button
+            onClick={onCalculateTaxes}
+            disabled={isCalculating}
+            variant="outline"
+            size="sm"
+          >
+            {isCalculating ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {t.calculating}
+              </>
+            ) : (
+              <>
+                <Calculator className="mr-2 h-4 w-4" />
+                {t.calculateTaxes}
+              </>
+            )}
+          </Button>
+        </div>
+      )}
+
       {/* Tax Summary Cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <Card>
           <CardHeader className="pb-2">
             <CardDescription>{t.annualVat}</CardDescription>
             <CardTitle className="text-2xl">
-              {formatCurrency(summary.annual_vat_total ?? 0, currency)}
+              {formatCurrency(summary.annualVatTotal ?? 0, currency)}
             </CardTitle>
           </CardHeader>
         </Card>
@@ -88,7 +130,7 @@ export function TaxSummaryView({
           <CardHeader className="pb-2">
             <CardDescription>{t.corporateTax}</CardDescription>
             <CardTitle className="text-2xl">
-              {formatCurrency(summary.annual_corporate_tax ?? 0, currency)}
+              {formatCurrency(summary.annualCorporateTax ?? 0, currency)}
             </CardTitle>
           </CardHeader>
         </Card>
@@ -96,7 +138,7 @@ export function TaxSummaryView({
           <CardHeader className="pb-2">
             <CardDescription>{t.withholdingTax}</CardDescription>
             <CardTitle className="text-2xl">
-              {formatCurrency(summary.annual_withholding_tax ?? 0, currency)}
+              {formatCurrency(summary.annualWithholdingTax ?? 0, currency)}
             </CardTitle>
           </CardHeader>
         </Card>
@@ -104,7 +146,7 @@ export function TaxSummaryView({
           <CardHeader className="pb-2">
             <CardDescription>{t.totalLiability}</CardDescription>
             <CardTitle className="text-2xl">
-              {formatCurrency(summary.total_tax_liability ?? 0, currency)}
+              {formatCurrency(summary.totalTaxLiability ?? 0, currency)}
             </CardTitle>
           </CardHeader>
         </Card>
@@ -123,7 +165,7 @@ export function TaxSummaryView({
               </p>
               <p className="text-lg font-semibold">
                 {formatCurrency(
-                  vatBreakdown.standard_rate_19_percent ?? 0,
+                  vatBreakdown.standardRate19Percent ?? 0,
                   currency
                 )}
               </p>
@@ -132,7 +174,7 @@ export function TaxSummaryView({
               <p className="text-muted-foreground text-sm">{t.reducedRate13}</p>
               <p className="text-lg font-semibold">
                 {formatCurrency(
-                  vatBreakdown.reduced_rate_13_percent ?? 0,
+                  vatBreakdown.reducedRate13Percent ?? 0,
                   currency
                 )}
               </p>
@@ -141,7 +183,7 @@ export function TaxSummaryView({
               <p className="text-muted-foreground text-sm">{t.reducedRate7}</p>
               <p className="text-lg font-semibold">
                 {formatCurrency(
-                  vatBreakdown.reduced_rate_7_percent ?? 0,
+                  vatBreakdown.reducedRate7Percent ?? 0,
                   currency
                 )}
               </p>
@@ -157,31 +199,28 @@ export function TaxSummaryView({
             <CardTitle>{t.taxCalendar}</CardTitle>
           </CardHeader>
           <CardContent>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t.periodColumn}</TableHead>
-                  <TableHead>{t.descriptionColumn}</TableHead>
-                  <TableHead>{t.dueColumn}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {taxCalendar.map((item, idx) => {
-                  const periodDisplay = item?.period ?? '';
-                  const descriptionDisplay = item?.description ?? '';
-                  const dueDisplay = item?.due_date
-                    ? formatDate(item.due_date, lang)
-                    : '';
-                  return (
-                    <TableRow key={idx}>
-                      <TableCell>{periodDisplay}</TableCell>
-                      <TableCell>{descriptionDisplay}</TableCell>
-                      <TableCell>{dueDisplay}</TableCell>
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t.periodColumn}</TableHead>
+                    <TableHead>{t.descriptionColumn}</TableHead>
+                    <TableHead>{t.dueColumn}</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {taxCalendar.map((item, idx) => (
+                    <TableRow key={item.period ?? idx}>
+                      <TableCell>{item.period}</TableCell>
+                      <TableCell>{item.description}</TableCell>
+                      <TableCell>
+                        {item.dueDate ? formatDate(item.dueDate, lang) : '-'}
+                      </TableCell>
                     </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           </CardContent>
         </Card>
       )}
@@ -193,44 +232,48 @@ export function TaxSummaryView({
             <CardTitle>{t.monthlyDetails}</CardTitle>
           </CardHeader>
           <CardContent>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t.monthColumn}</TableHead>
-                  <TableHead className="text-right">{t.vatColumn}</TableHead>
-                  <TableHead className="text-right">
-                    {t.corporateTaxShort}
-                  </TableHead>
-                  <TableHead className="text-right">
-                    {t.withholdingTaxShort}
-                  </TableHead>
-                  <TableHead className="text-right">{t.totalColumn}</TableHead>
-                  <TableHead>{t.dueColumn}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {monthlyDetails.map((month, idx) => (
-                  <TableRow key={idx}>
-                    <TableCell>{month?.period ?? ''}</TableCell>
-                    <TableCell className="text-right">
-                      {formatCurrency(month.vat_total ?? 0, currency)}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      {formatCurrency(month.corporate_tax_due ?? 0, currency)}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      {formatCurrency(month.withholding_tax ?? 0, currency)}
-                    </TableCell>
-                    <TableCell className="text-right font-medium">
-                      {formatCurrency(month.total_tax_liability ?? 0, currency)}
-                    </TableCell>
-                    <TableCell>
-                      {month?.due_date ? formatDate(month.due_date, lang) : ''}
-                    </TableCell>
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t.monthColumn}</TableHead>
+                    <TableHead className="text-right">{t.vatColumn}</TableHead>
+                    <TableHead className="text-right">
+                      {t.corporateTaxShort}
+                    </TableHead>
+                    <TableHead className="text-right">
+                      {t.withholdingTaxShort}
+                    </TableHead>
+                    <TableHead className="text-right">
+                      {t.totalColumn}
+                    </TableHead>
+                    <TableHead>{t.dueColumn}</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+                </TableHeader>
+                <TableBody>
+                  {monthlyDetails.map((month, idx) => (
+                    <TableRow key={month.month ?? month.period ?? idx}>
+                      <TableCell>{month.period}</TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(month.vatTotal ?? 0, currency)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(month.corporateTaxDue ?? 0, currency)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {formatCurrency(month.withholdingTax ?? 0, currency)}
+                      </TableCell>
+                      <TableCell className="text-right font-medium">
+                        {formatCurrency(month.totalTaxLiability ?? 0, currency)}
+                      </TableCell>
+                      <TableCell>
+                        {month.dueDate ? formatDate(month.dueDate, lang) : '-'}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
           </CardContent>
         </Card>
       )}

--- a/components/app/business-statistics/BusinessStatistics.tsx
+++ b/components/app/business-statistics/BusinessStatistics.tsx
@@ -25,6 +25,7 @@ import { type Dictionary } from '@/get-dictionary';
 import { BusinessService, ProductsService } from '@/lib/requests';
 import { formatICU } from '@/lib/icu-formatter';
 import { Chatbot } from '@/components/app/business/Chatbot';
+import { BusinessStatisticsSkeleton } from './BusinessStatisticsSkeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
   Card,
@@ -254,20 +255,7 @@ export default function BusinessStatistics({
       </Alert>
     );
   } else if (loading) {
-    content = (
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
-        {[1, 2, 3, 4, 5].map((i) => (
-          <div
-            key={i}
-            className="dark:bg-card/90 space-y-3 rounded-lg border-0 bg-white/90 p-4 shadow-sm"
-          >
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-8 w-20" />
-            <Skeleton className="h-3 w-32" />
-          </div>
-        ))}
-      </div>
-    );
+    content = <BusinessStatisticsSkeleton />;
   } else if (statistics === undefined) {
     content = (
       <Alert>

--- a/components/app/business-statistics/BusinessStatisticsSkeleton.tsx
+++ b/components/app/business-statistics/BusinessStatisticsSkeleton.tsx
@@ -1,0 +1,72 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function BusinessStatisticsSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* KPI Cards Skeleton */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        {Array.from({ length: 5 }, (_, i) => (
+          <Card key={i} className="border-0 shadow-sm">
+            <CardContent className="p-4">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-4 w-4" />
+                <Skeleton className="h-3 w-20" />
+              </div>
+              <Skeleton className="mt-2 h-8 w-24" />
+              <Skeleton className="mt-1 h-3 w-32" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Charts Row 1 */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+        <Card className="border-0 shadow-sm lg:col-span-8">
+          <CardHeader className="pb-2">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="mt-1 h-3 w-48" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="aspect-auto h-[320px] w-full" />
+          </CardContent>
+        </Card>
+        <Card className="border-0 shadow-sm lg:col-span-4">
+          <CardHeader className="pb-2">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="mt-1 h-3 w-40" />
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col items-center justify-center py-6">
+              <Skeleton className="h-24 w-24 rounded-full" />
+              <Skeleton className="mt-4 h-8 w-24" />
+              <Skeleton className="mt-1 h-4 w-32" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Charts Row 2 */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+        <Card className="border-0 shadow-sm lg:col-span-6">
+          <CardHeader className="pb-2">
+            <Skeleton className="h-5 w-36" />
+            <Skeleton className="mt-1 h-3 w-44" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="aspect-auto h-[280px] w-full" />
+          </CardContent>
+        </Card>
+        <Card className="border-0 shadow-sm lg:col-span-6">
+          <CardHeader className="pb-2">
+            <Skeleton className="h-5 w-40" />
+            <Skeleton className="mt-1 h-3 w-44" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="aspect-auto h-[280px] w-full" />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/components/app/business/Chatbot.tsx
+++ b/components/app/business/Chatbot.tsx
@@ -14,6 +14,8 @@ import {
   Send,
   AlertCircle,
   Sparkles,
+  User,
+  RotateCcw,
 } from 'lucide-react';
 import FocusLock from 'react-focus-lock';
 import { cn } from '@/lib/utils';
@@ -37,8 +39,8 @@ import {
   CardContent,
   CardFooter,
 } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 
 const CHAT_STORAGE_KEY = 'accountia_chat_history';
 
@@ -57,6 +59,68 @@ const getChatStorageKey = (biz?: string, user?: string, ctx?: string) => {
     : `${CHAT_STORAGE_KEY}_individual`;
 };
 
+/**
+ * Helper to handle **bold** text
+ */
+function renderTextWithBold(text: string) {
+  const parts = text.split(/(\*\*.*?\*\*)/g);
+  return parts.map((part, i) => {
+    if (part.startsWith('**') && part.endsWith('**')) {
+      return (
+        <strong key={i} className="text-foreground font-bold">
+          {part.slice(2, -2)}
+        </strong>
+      );
+    }
+    return part;
+  });
+}
+
+/**
+ * Simple component to render content with basic markdown-like formatting
+ */
+function FormattedContent({ content }: { content: string }) {
+  const lines = content.split('\n');
+
+  return (
+    <div className="space-y-1.5">
+      {lines.map((line, i) => {
+        // Headers (## Header)
+        if (line.startsWith('## ')) {
+          return (
+            <h3 key={i} className="text-foreground mt-3 mb-1 text-sm font-bold">
+              {line.replace('## ', '')}
+            </h3>
+          );
+        }
+
+        // Bullet points (* Item)
+        if (line.trim().startsWith('* ') || line.trim().startsWith('- ')) {
+          const text = line.trim().replace(/^[ *-]\s+/, '');
+          return (
+            <div key={i} className="flex gap-2 pl-1">
+              <span className="mt-2 h-1 w-1 shrink-0 rounded-full bg-current opacity-60" />
+              <span>{renderTextWithBold(text)}</span>
+            </div>
+          );
+        }
+
+        // Empty line
+        if (!line.trim()) {
+          return <div key={i} className="h-1.5" />;
+        }
+
+        // Regular line
+        return (
+          <p key={i} className="leading-relaxed">
+            {renderTextWithBold(line)}
+          </p>
+        );
+      })}
+    </div>
+  );
+}
+
 export function Chatbot({
   businessId,
   context,
@@ -72,7 +136,10 @@ export function Chatbot({
   const [inputValue, setInputValue] = useState('');
   const [error, setError] = useState<string | undefined>();
   const [isStreaming, setIsStreaming] = useState(false);
-  const [isConnected, setIsConnected] = useState(false);
+  const [connectionState, setConnectionState] = useState<
+    'connecting' | 'connected' | 'failed'
+  >('connecting');
+  const isConnected = connectionState === 'connected';
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   // Track which storage key we've loaded for this session to avoid
@@ -94,13 +161,13 @@ export function Chatbot({
 
         await client.connect({
           onConnected: (data: ChatConnectedEvent) => {
-            setIsConnected(true);
+            setConnectionState('connected');
             setError(undefined);
             // capture connected user id so we can scope stored history
             if (data?.userId) setUserId(data.userId);
           },
           onConnectError: (data: ChatConnectErrorEvent) => {
-            setIsConnected(false);
+            setConnectionState('failed');
             setError(data.message || t.connectionFailed);
           },
           onChunk: (data: ChatMessageChunkEvent) => {
@@ -151,7 +218,7 @@ export function Chatbot({
             });
           },
           onDisconnect: () => {
-            setIsConnected(false);
+            setConnectionState('failed');
           },
         });
       } catch (error_) {
@@ -311,8 +378,16 @@ export function Chatbot({
   const clearChat = useCallback(() => {
     setMessages([]);
     setError(undefined);
-    const storageKey = getChatStorageKey(businessId, userId, context);
-    localStorage.removeItem(storageKey);
+    // Remove all possible storage key variants to prevent legacy data reappearing
+    const keysToRemove = [
+      getChatStorageKey(businessId, userId, context),
+      getChatStorageKey(businessId, undefined, context),
+      getChatStorageKey(businessId, userId),
+      getChatStorageKey(businessId),
+      getChatStorageKey(undefined, userId),
+      getChatStorageKey(),
+    ];
+    for (const key of keysToRemove) localStorage.removeItem(key);
   }, [businessId, userId, context]);
 
   return (
@@ -346,48 +421,55 @@ export function Chatbot({
           aria-hidden={!isOpen}
         >
           {/* Header */}
-          <CardHeader className="bg-primary text-primary-foreground flex flex-row items-center justify-between gap-4 border-b border-none! px-4! py-4">
+          <CardHeader className="bg-primary/5 dark:bg-primary/10 flex flex-row items-center justify-between gap-4 border-b px-4! py-3!">
             <div className="flex items-center gap-3">
-              <div className="bg-primary-foreground/20 rounded-lg p-2 backdrop-blur-sm">
-                <Bot
-                  size={28}
-                  className="text-primary-foreground"
-                  aria-hidden
-                />
+              <div className="bg-primary ring-primary/10 flex h-10 w-10 items-center justify-center rounded-xl shadow-lg ring-4">
+                <Sparkles size={20} className="text-primary-foreground" />
               </div>
               <div>
-                <h3 className="leading-tight font-semibold tracking-tight">
-                  {t.title}
-                </h3>
-                <div className="mt-0.5 flex items-center gap-1">
-                  <Sparkles
-                    size={10}
-                    className="fill-primary-foreground/80"
-                    aria-hidden
-                  />
-                  <Badge
-                    variant="secondary"
+                <h3 className="text-sm font-bold tracking-tight">{t.title}</h3>
+                <div className="mt-0.5 flex items-center gap-1.5">
+                  <span
                     className={cn(
-                      'text-xs',
-                      isConnected
-                        ? 'bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/30'
-                        : 'bg-amber-500/20 text-amber-100 hover:bg-amber-500/30'
+                      'h-1.5 w-1.5 rounded-full',
+                      connectionState === 'connected'
+                        ? 'animate-pulse bg-emerald-500'
+                        : connectionState === 'failed'
+                          ? 'bg-red-500'
+                          : 'bg-amber-500'
                     )}
-                  >
-                    {isConnected ? t.online : 'Connecting...'}
-                  </Badge>
+                  />
+                  <span className="text-muted-foreground text-[10px] font-medium tracking-wider uppercase">
+                    {connectionState === 'connected'
+                      ? t.online
+                      : connectionState === 'failed'
+                        ? t.failed
+                        : t.connecting}
+                  </span>
                 </div>
               </div>
             </div>
-            <Button
-              onClick={() => setIsOpen(false)}
-              variant="ghost"
-              size="icon"
-              className="text-primary-foreground hover:bg-primary-foreground/20"
-              aria-label={t.closeButton}
-            >
-              <X size={20} aria-hidden />
-            </Button>
+            <div className="flex items-center gap-1">
+              <Button
+                onClick={clearChat}
+                variant="ghost"
+                size="icon"
+                className="text-muted-foreground hover:text-foreground h-8 w-8 transition-colors"
+                title={t.clearChat}
+                aria-label={t.clearChat}
+              >
+                <RotateCcw size={16} />
+              </Button>
+              <Button
+                onClick={() => setIsOpen(false)}
+                variant="ghost"
+                size="icon"
+                className="text-muted-foreground hover:text-foreground h-8 w-8"
+                aria-label={t.closeButton}
+              >
+                <X size={18} />
+              </Button>
+            </div>
           </CardHeader>
 
           {/* Messages Area */}
@@ -417,23 +499,39 @@ export function Chatbot({
                     <div
                       key={index}
                       className={cn(
-                        'flex transition-all duration-500',
-                        msg.role === 'user' ? 'justify-end' : 'justify-start'
+                        'flex gap-3 transition-all duration-500',
+                        msg.role === 'user'
+                          ? 'flex-row-reverse justify-end'
+                          : 'flex-row justify-start'
                       )}
                     >
+                      <Avatar className="border-muted/50 mt-1 h-8 w-8 shrink-0 border shadow-sm">
+                        <AvatarFallback
+                          className={cn(
+                            'text-[10px] font-bold',
+                            msg.role === 'user'
+                              ? 'bg-primary text-primary-foreground'
+                              : 'bg-slate-600 text-white'
+                          )}
+                        >
+                          {msg.role === 'user' ? (
+                            <User size={14} />
+                          ) : (
+                            <Bot size={14} />
+                          )}
+                        </AvatarFallback>
+                      </Avatar>
+
                       <div
                         className={cn(
-                          'max-w-[85%] rounded-lg px-3 py-2 text-sm',
+                          'relative max-w-[80%] rounded-2xl px-4 py-3 text-sm shadow-sm transition-all',
                           msg.role === 'user'
-                            ? 'bg-primary text-primary-foreground rounded-br-none'
-                            : 'bg-muted text-muted-foreground rounded-bl-none border'
+                            ? 'bg-primary text-primary-foreground rounded-tr-none'
+                            : 'bg-muted/50 text-foreground border-muted/30 rounded-tl-none border backdrop-blur-sm dark:bg-slate-800/60'
                         )}
                         role="article"
-                        aria-label={`${
-                          msg.role === 'user' ? t.userMessage : t.aiResponse
-                        }: ${msg.content.slice(0, 50)}...`}
                       >
-                        <p className="whitespace-pre-wrap">{msg.content}</p>
+                        <FormattedContent content={msg.content} />
                       </div>
                     </div>
                   ))
@@ -475,49 +573,44 @@ export function Chatbot({
           </CardContent>
 
           {/* Input Area */}
-          <CardFooter className="flex-col gap-3 border-t py-3">
+          <CardFooter className="bg-muted/5 flex-col gap-3 border-t px-4 py-3">
             <div className="relative flex w-full items-center gap-2">
-              <Input
-                ref={inputRef}
-                type="text"
-                value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder={t.messagePlaceholder}
-                disabled={isStreaming}
-                aria-label="Message input"
-                className="text-sm"
-              />
-              <Button
-                onClick={handleSendMessage}
-                disabled={!inputValue.trim() || isStreaming || !isConnected}
-                size="icon"
-                className="shrink-0"
-                aria-label={t.sendMessage}
-              >
-                {isStreaming ? (
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                ) : (
-                  <Send size={16} aria-hidden />
-                )}
-              </Button>
-            </div>
-            <div className="flex w-full items-center justify-between">
-              <p className="text-muted-foreground text-xs tracking-wide">
-                {t.disclaimer}
-              </p>
-              {messages.length > 0 && (
+              <div className="relative flex-1">
+                <Input
+                  ref={inputRef}
+                  type="text"
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder={
+                    connectionState === 'connected'
+                      ? t.messagePlaceholder
+                      : connectionState === 'failed'
+                        ? t.failed
+                        : t.connecting
+                  }
+                  disabled={isStreaming || !isConnected}
+                  className="focus-visible:ring-primary h-11 rounded-xl pr-12 text-sm shadow-xs transition-shadow"
+                  aria-label={t.messagePlaceholder}
+                />
                 <Button
-                  onClick={clearChat}
-                  variant="ghost"
-                  size="sm"
-                  className="h-auto p-0 text-xs"
-                  aria-label={t.clearChat}
+                  onClick={handleSendMessage}
+                  disabled={!inputValue.trim() || isStreaming || !isConnected}
+                  size="icon"
+                  className="bg-primary hover:bg-primary/90 absolute top-1 right-1 h-9 w-9 rounded-lg shadow-sm transition-transform hover:scale-105 active:scale-95"
+                  aria-label={t.sendMessage}
                 >
-                  {t.clearChat}
+                  {isStreaming ? (
+                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                  ) : (
+                    <Send size={16} />
+                  )}
                 </Button>
-              )}
+              </div>
             </div>
+            <p className="text-muted-foreground text-center text-[10px] opacity-70">
+              {t.disclaimer}
+            </p>
           </CardFooter>
         </Card>
       </FocusLock>

--- a/components/app/invoices/Invoices.tsx
+++ b/components/app/invoices/Invoices.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { loadStripe } from '@stripe/stripe-js';
@@ -20,6 +21,8 @@ import {
   RotateCcw,
   X,
   CreditCard,
+  Link2,
+  ExternalLink,
 } from 'lucide-react';
 import {
   Card,
@@ -63,13 +66,14 @@ import { type Locale } from '@/i18n-config';
 import { type Dictionary } from '@/get-dictionary';
 import { formatDate } from '@/lib/date-utils';
 import { cn } from '@/lib/utils';
-import { InvoicesService } from '@/lib/requests';
+import { InvoicesService, AuthService } from '@/lib/requests';
 import { getStatusLabel } from '@/lib/status-labels';
 import { toast } from 'sonner';
 import type {
   ReceivedInvoiceListResponse,
   InvoiceStatus,
   InvoiceReceiptResponseDto,
+  UserStripeConnectStatusResponse,
 } from '@/types/services';
 import { localizeErrorMessage } from '@/lib/error-localization';
 import { env } from '@/env';
@@ -173,6 +177,56 @@ export default function Invoices({
     staleTime: 10 * 60 * 1000, // 10 minutes
     gcTime: 45 * 60 * 1000, // 45 minutes
   });
+
+  // Stripe Connect status for individual users
+  const {
+    data: stripeStatus,
+    isLoading: isStripeStatusLoading,
+    isError: isStripeStatusError,
+  } = useQuery<UserStripeConnectStatusResponse>({
+    queryKey: ['user-stripe-status'],
+    queryFn: () => AuthService.getStripeConnectStatus(),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+
+  const router = useRouter();
+
+  const { mutate: getStripeOnboardingLink, isPending: isGeneratingLink } =
+    useMutation({
+      mutationFn: () => AuthService.getStripeOnboardingLink(),
+      onSuccess: (data) => {
+        if (data.onboardingUrl) {
+          // Navigate to Stripe onboarding in same tab (better UX, no popup blockers)
+          router.push(data.onboardingUrl);
+        } else {
+          toast.error(t.stripeConnect.onboardingUrlMissing);
+        }
+        // Invalidate stripe status query after navigating
+        void queryClient.invalidateQueries({
+          queryKey: ['user-stripe-status'],
+        });
+      },
+      onError: (error: unknown) => {
+        toast.error(
+          localizeErrorMessage(error, dictionary, t.stripeConnect.statusError)
+        );
+      },
+    });
+
+  // Handle visibility change with cleanup
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        void queryClient.invalidateQueries({
+          queryKey: ['user-stripe-status'],
+        });
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [queryClient]);
 
   // Handle successful verification
   // useEffect de vérification supprimé car plus nécessaire
@@ -422,6 +476,93 @@ export default function Invoices({
           <CardContent />
         </Card>
       </div>
+
+      {/* Stripe Connect Card */}
+      <Card className="dark:bg-card/90 border-0 bg-white/90 shadow-sm">
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Link2 className="h-5 w-5" />
+                {t.stripeConnect.title}
+              </CardTitle>
+              <CardDescription>{t.stripeConnect.description}</CardDescription>
+            </div>
+            <div className="flex items-center gap-3">
+              {isStripeStatusLoading ? (
+                <Skeleton className="h-6 w-24" />
+              ) : isStripeStatusError ? (
+                <Badge
+                  variant="secondary"
+                  className="bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-100"
+                >
+                  <AlertCircle className="mr-1 h-3 w-3" />
+                  {t.stripeConnect.error}
+                </Badge>
+              ) : stripeStatus?.isConnected ? (
+                <Badge
+                  variant="secondary"
+                  className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-100"
+                >
+                  <CheckCircle className="mr-1 h-3 w-3" />
+                  {t.stripeConnect.connected}
+                </Badge>
+              ) : (
+                <Badge
+                  variant="secondary"
+                  className="bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-100"
+                >
+                  {t.stripeConnect.notConnected}
+                </Badge>
+              )}
+              {!isStripeStatusLoading &&
+                !isStripeStatusError &&
+                !stripeStatus?.isConnected && (
+                  <Button
+                    size="sm"
+                    onClick={() => getStripeOnboardingLink()}
+                    disabled={isGeneratingLink}
+                  >
+                    {isGeneratingLink ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        {t.stripeConnect.preparingLink}
+                      </>
+                    ) : (
+                      <>
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                        {t.stripeConnect.connectButton}
+                      </>
+                    )}
+                  </Button>
+                )}
+              {!isStripeStatusLoading &&
+                stripeStatus?.isConnected &&
+                stripeStatus?.stripeConnectId && (
+                  <span className="text-muted-foreground hidden font-mono text-xs sm:inline">
+                    ****
+                    {stripeStatus.stripeConnectId.length >= 4
+                      ? stripeStatus.stripeConnectId.slice(-4)
+                      : stripeStatus.stripeConnectId}
+                  </span>
+                )}
+            </div>
+          </div>
+          {!isStripeStatusLoading &&
+            (isStripeStatusError ? (
+              <p className="text-muted-foreground mt-2 text-sm">
+                {t.stripeConnect.statusError}
+              </p>
+            ) : (
+              !stripeStatus?.isConnected && (
+                <p className="text-muted-foreground mt-2 text-sm">
+                  {t.stripeConnect.connectHint}
+                </p>
+              )
+            ))}
+        </CardHeader>
+        <CardContent />
+      </Card>
 
       {/* Main Table Card — blurred while awaiting payment confirmation */}
       <div className="relative">

--- a/dictionaries/ar.json
+++ b/dictionaries/ar.json
@@ -518,6 +518,18 @@
         "cancel": "إلغاء",
         "confirm": "تأكيد الدفع",
         "errorMessage": "فشل تحديث حالة الفاتورة. يرجى المحاولة مرة أخرى."
+      },
+      "stripeConnect": {
+        "title": "Stripe Connect",
+        "description": "قم بتوصيل حساب Stripe الخاص بك لاستلام المدفوعات مقابل الفواتير التي تصدرها.",
+        "connected": "متصل",
+        "notConnected": "غير متصل",
+        "connectHint": "قم بتوصيل حساب Stripe الخاص بك لبدء استلام المدفوعات.",
+        "connectButton": "توصيل حساب Stripe",
+        "preparingLink": "جاري إعداد الرابط...",
+        "statusError": "تعذر التحقق من حالة Stripe.",
+        "error": "خطأ",
+        "onboardingUrlMissing": "لم يتم استلام رابط الإعداد. يرجى المحاولة مرة أخرى."
       }
     },
     "businessApplication": {
@@ -735,6 +747,8 @@
         "openButton": "فتح الدردشة",
         "closeButton": "إغلاق الدردشة",
         "online": "متصل",
+        "connecting": "جاري الاتصال...",
+        "failed": "غير متصل",
         "messagePlaceholder": "اكتب رسالتك...",
         "clearChat": "مسح",
         "disclaimer": "قد يرتكب Accountia AI أخطاء.",
@@ -790,8 +804,6 @@
       "overviewTitle": "نظرة عامة",
       "overviewDescription": "اختر مهمة مكتملة لعرض النتائج",
       "noCompletedJobs": "لا توجد مهام مكتملة بعد",
-      "journalEntries": "قيود يومية",
-      "reports": "تقارير",
       "jobsTitle": "المهام المحاسبية",
       "jobsDescription": "عرض وإدارة مهامك المحاسبية",
       "noJobs": "لا توجد مهام بعد. أنشئ أول مهمة محاسبية للبدء.",
@@ -857,7 +869,15 @@
       "date": "التاريخ",
       "account": "الحساب",
       "debit": "مدين",
-      "credit": "دائن"
+      "credit": "دائن",
+      "calculating": "جاري الحساب...",
+      "calculateTaxes": "حساب الضرائب",
+      "taxesCalculated": "تم حساب الضرائب بنجاح",
+      "calculateTaxesError": "فشل في حساب الضرائب",
+      "accountsReceivable": "الذمم المدينة",
+      "accountsPayable": "الذمم الدائنة",
+      "cashPosition": "الموقف النقدي",
+      "reports": "التقارير"
     },
     "businessProducts": {
       "title": "المنتجات",

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -526,6 +526,18 @@
         "cancel": "Cancel",
         "confirm": "Confirm Payment",
         "errorMessage": "Failed to update invoice status. Please try again."
+      },
+      "stripeConnect": {
+        "title": "Stripe Connect",
+        "description": "Connect your Stripe account to receive payments for invoices you issue.",
+        "connected": "Connected",
+        "notConnected": "Not connected",
+        "connectHint": "Connect your Stripe account to start receiving payments.",
+        "connectButton": "Connect Stripe Account",
+        "preparingLink": "Preparing link...",
+        "statusError": "Unable to verify Stripe status.",
+        "error": "Error",
+        "onboardingUrlMissing": "No onboarding URL received. Please try again."
       }
     },
     "businessApplication": {
@@ -743,6 +755,8 @@
         "openButton": "Open chat",
         "closeButton": "Close chat",
         "online": "Online",
+        "connecting": "Connecting...",
+        "failed": "Offline",
         "messagePlaceholder": "Write your message...",
         "clearChat": "Clear",
         "disclaimer": "Accountia AI may make mistakes.",
@@ -798,8 +812,6 @@
       "overviewTitle": "Overview",
       "overviewDescription": "Select a completed job to view results",
       "noCompletedJobs": "No completed jobs yet",
-      "journalEntries": "journal entries",
-      "reports": "reports",
       "jobsTitle": "Accounting Jobs",
       "jobsDescription": "View and manage your accounting jobs",
       "noJobs": "No jobs yet. Create your first accounting job to get started.",
@@ -865,7 +877,15 @@
       "date": "Date",
       "account": "Account",
       "debit": "Debit",
-      "credit": "Credit"
+      "credit": "Credit",
+      "calculating": "Calculating...",
+      "calculateTaxes": "Calculate Taxes",
+      "taxesCalculated": "Taxes calculated successfully",
+      "calculateTaxesError": "Failed to calculate taxes",
+      "accountsReceivable": "Accounts Receivable",
+      "accountsPayable": "Accounts Payable",
+      "cashPosition": "Cash Position",
+      "reports": "Reports"
     },
     "businessProducts": {
       "title": "Products",

--- a/dictionaries/fr.json
+++ b/dictionaries/fr.json
@@ -526,6 +526,18 @@
         "cancel": "Annuler",
         "confirm": "Confirmer le paiement",
         "errorMessage": "Échec de la mise à jour du statut de la facture. Veuillez réessayer."
+      },
+      "stripeConnect": {
+        "title": "Stripe Connect",
+        "description": "Connectez votre compte Stripe pour recevoir les paiements des factures que vous émettez.",
+        "connected": "Connecté",
+        "notConnected": "Non connecté",
+        "connectHint": "Connectez votre compte Stripe pour commencer à recevoir des paiements.",
+        "connectButton": "Connecter un compte Stripe",
+        "preparingLink": "Préparation du lien...",
+        "statusError": "Impossible de vérifier le statut Stripe.",
+        "error": "Erreur",
+        "onboardingUrlMissing": "Aucun lien d'onboarding reçu. Veuillez réessayer."
       }
     },
     "businessApplication": {
@@ -743,6 +755,8 @@
         "openButton": "Ouvrir le chat",
         "closeButton": "Fermer le chat",
         "online": "En ligne",
+        "connecting": "Connexion...",
+        "failed": "Hors ligne",
         "messagePlaceholder": "Écrivez votre message...",
         "clearChat": "Effacer",
         "disclaimer": "Accountia AI peut faire des erreurs.",
@@ -798,8 +812,6 @@
       "overviewTitle": "Vue d'ensemble",
       "overviewDescription": "Sélectionnez une tâche terminée pour voir les résultats",
       "noCompletedJobs": "Aucune tâche terminée pour le moment",
-      "journalEntries": "écritures comptables",
-      "reports": "rapports",
       "jobsTitle": "Tâches comptables",
       "jobsDescription": "Consultez et gérez vos tâches comptables",
       "noJobs": "Aucune tâche pour le moment. Créez votre première tâche comptable pour commencer.",
@@ -865,7 +877,15 @@
       "date": "Date",
       "account": "Compte",
       "debit": "Débit",
-      "credit": "Crédit"
+      "credit": "Crédit",
+      "calculating": "Calcul en cours...",
+      "calculateTaxes": "Calculer les taxes",
+      "taxesCalculated": "Taxes calculées avec succès",
+      "calculateTaxesError": "Échec du calcul des taxes",
+      "accountsReceivable": "Créances clients",
+      "accountsPayable": "Dettes fournisseurs",
+      "cashPosition": "Position de trésorerie",
+      "reports": "Rapports"
     },
     "businessProducts": {
       "title": "Produits",

--- a/lib/requests.ts
+++ b/lib/requests.ts
@@ -90,6 +90,8 @@ export const API_CONFIG = {
     GOOGLE: 'auth/google',
     GOOGLE_EXCHANGE: 'auth/google/exchange',
     GOOGLE_CALLBACK: 'auth/google/callback',
+    STRIPE_ONBOARDING: 'auth/stripe/onboarding',
+    STRIPE_STATUS: 'auth/stripe/status',
   },
   BUSINESS: {
     APPLY: 'business/apply',
@@ -146,6 +148,7 @@ export const API_CONFIG = {
       'invoices/received/individual/{receiptId}/payments/checkout',
     CREATE_INDIVIDUAL_MOCK_PAYMENT:
       'invoices/received/individual/{receiptId}/payments/mock',
+    CONFIRM_PAYMENT: 'invoices/payments/confirm',
   },
   CHAT: {
     SEND_MESSAGE: 'chat/message',
@@ -165,10 +168,12 @@ export const API_CONFIG = {
     CREATE_JOB: 'accountant/jobs',
     LIST_JOBS: 'accountant/jobs',
     GET_JOB: 'accountant/jobs/{taskId}',
+    CANCEL_JOB: 'accountant/jobs/{taskId}',
     GET_JOB_RESULTS: 'accountant/jobs/{taskId}/results',
-    GET_HISTORY: 'accountant/business/{businessId}/history',
-    GET_WORK: 'accountant/business/{businessId}/work',
+    GET_HISTORY: 'accountant/history',
+    GET_WORK: 'accountant/work',
     GET_TAXES: 'accountant/taxes',
+    CALCULATE_TAXES: 'accountant/taxes/calculate',
     HEALTH: 'accountant/health',
   },
 } as const;

--- a/lib/services/accountant.ts
+++ b/lib/services/accountant.ts
@@ -1,44 +1,46 @@
 import type {
   CreateAccountingJobInput,
-  CreateAccountingJobWrapper,
-  ListAccountingJobsResponse,
-  AccountingJobStatus,
-  AccountingJobDetailsWrapper,
-  GetAccountingJobResultsWrapper,
-  AccountingHistoryWrapper,
-  AccountingWorkLogWrapper,
-  TaxSummaryWrapper,
-  AccountantHealthResponse,
-  CancelJobWrapper,
+  ListAccountingJobsQuery,
+  GetJobStatusParams,
+  GetJobStatusQuery,
+  GetJobResultsParams,
+  GetJobResultsQuery,
+  CancelJobParams,
+  CancelJobQuery,
+  GetAccountingHistoryQuery,
+  GetAllAccountantWorkQuery,
+  GetTaxesQuery,
+  CalculateTaxesQuery,
 } from '@/types/services';
-import { createAuthenticatedClient, API_CONFIG } from '@/lib/requests';
+import type {
+  CreateAccountingJobResponseDto,
+  ListAccountingJobsResponseDto,
+  GetJobStatusResponseDto,
+  GetJobResultsResponseDto,
+  CancelAccountingJobResponseDto,
+  GetAccountingHistoryResponseDto,
+  GetAllAccountantWorkResponseDto,
+  TunisianTaxSummaryResponseDto,
+  CalculateTaxResponseDto,
+  AccountantHealthResponseDto,
+} from '@/types/services';
+
+import {
+  createAuthenticatedClient,
+  publicClient,
+  API_CONFIG,
+} from '@/lib/requests';
 import { handleServiceError } from '@/lib/services/service-error';
 
 export const AccountantService = {
-  // Helper to unwrap API responses that are wrapped as { success: true, data: T }
-  _unwrap<T>(res: unknown): T {
-    if (
-      res &&
-      typeof res === 'object' &&
-      'success' in (res as Record<string, unknown>) &&
-      'data' in (res as Record<string, unknown>)
-    ) {
-      const obj = res as Record<string, unknown>;
-      return obj.data as T;
-    }
-    return res as T;
-  },
   async createJob(
-    data: CreateAccountingJobInput
-  ): Promise<CreateAccountingJobWrapper> {
+    payload: CreateAccountingJobInput
+  ): Promise<CreateAccountingJobResponseDto> {
     const client = createAuthenticatedClient();
     try {
-      // businessId is now part of CreateAccountingJobInput per new API docs
       const result = await client
-        .post(API_CONFIG.ACCOUNTANT.CREATE_JOB, {
-          json: data,
-        })
-        .json<CreateAccountingJobWrapper>();
+        .post(API_CONFIG.ACCOUNTANT.CREATE_JOB, { json: payload })
+        .json<CreateAccountingJobResponseDto>();
       return result;
     } catch (error: unknown) {
       return handleServiceError(error);
@@ -46,23 +48,17 @@ export const AccountantService = {
   },
 
   async listJobs(
-    businessId: string,
-    status?: AccountingJobStatus,
-    limit?: number
-  ): Promise<ListAccountingJobsResponse> {
+    params?: ListAccountingJobsQuery
+  ): Promise<ListAccountingJobsResponseDto> {
     const client = createAuthenticatedClient();
     try {
-      // Controller expects camelCase businessId
-      const searchParams: Record<string, string | number> = { businessId };
-      if (status) {
-        searchParams.status = status;
-      }
-      if (limit !== undefined) {
-        searchParams.limit = limit;
-      }
+      const searchParams: Record<string, string | number> = {};
+      if (params?.businessId != undefined)
+        searchParams.businessId = params.businessId;
+      if (params?.limit != undefined) searchParams.limit = params.limit;
       const result = await client
         .get(API_CONFIG.ACCOUNTANT.LIST_JOBS, { searchParams })
-        .json<ListAccountingJobsResponse>();
+        .json<ListAccountingJobsResponseDto>();
       return result;
     } catch (error: unknown) {
       return handleServiceError(error);
@@ -70,20 +66,21 @@ export const AccountantService = {
   },
 
   async getJobStatus(
-    businessId: string,
-    taskId: string
-  ): Promise<AccountingJobDetailsWrapper> {
+    params: GetJobStatusParams,
+    query?: GetJobStatusQuery
+  ): Promise<GetJobStatusResponseDto> {
     const client = createAuthenticatedClient();
     try {
+      const endpoint = API_CONFIG.ACCOUNTANT.GET_JOB.replace(
+        '{taskId}',
+        encodeURIComponent(params.taskId)
+      );
+      const searchParams: Record<string, string> = {};
+      if (query?.businessId != undefined)
+        searchParams.businessId = query.businessId;
       const result = await client
-        .get(
-          API_CONFIG.ACCOUNTANT.GET_JOB.replace(
-            '{taskId}',
-            encodeURIComponent(taskId)
-          ),
-          { searchParams: { businessId } }
-        )
-        .json<AccountingJobDetailsWrapper>();
+        .get(endpoint, { searchParams })
+        .json<GetJobStatusResponseDto>();
       return result;
     } catch (error: unknown) {
       return handleServiceError(error);
@@ -91,83 +88,21 @@ export const AccountantService = {
   },
 
   async getJobResults(
-    businessId: string,
-    taskId: string
-  ): Promise<GetAccountingJobResultsWrapper> {
+    params: GetJobResultsParams,
+    query?: GetJobResultsQuery
+  ): Promise<GetJobResultsResponseDto> {
     const client = createAuthenticatedClient();
     try {
-      const result = await client
-        .get(
-          API_CONFIG.ACCOUNTANT.GET_JOB_RESULTS.replace(
-            '{taskId}',
-            encodeURIComponent(taskId)
-          ),
-          { searchParams: { businessId } }
-        )
-        .json<GetAccountingJobResultsWrapper>();
-      return result;
-    } catch (error: unknown) {
-      return handleServiceError(error);
-    }
-  },
-
-  async getHistory(
-    businessId: string,
-    limit?: number
-  ): Promise<AccountingHistoryWrapper> {
-    const client = createAuthenticatedClient();
-    try {
-      const url = API_CONFIG.ACCOUNTANT.GET_HISTORY.replace(
-        '{businessId}',
-        encodeURIComponent(businessId)
-      );
-      const searchParams: Record<string, string | number> = {};
-      if (limit !== undefined) searchParams.limit = limit;
-      const result = await client
-        .get(url, { searchParams })
-        .json<AccountingHistoryWrapper>();
-      return result;
-    } catch (error: unknown) {
-      return handleServiceError(error);
-    }
-  },
-
-  async getWork(
-    businessId: string,
-    startDate?: string,
-    endDate?: string,
-    status?: AccountingJobStatus
-  ): Promise<AccountingWorkLogWrapper> {
-    const client = createAuthenticatedClient();
-    try {
-      const url = API_CONFIG.ACCOUNTANT.GET_WORK.replace(
-        '{businessId}',
-        encodeURIComponent(businessId)
+      const endpoint = API_CONFIG.ACCOUNTANT.GET_JOB_RESULTS.replace(
+        '{taskId}',
+        encodeURIComponent(params.taskId)
       );
       const searchParams: Record<string, string> = {};
-      if (startDate) searchParams.start_date = startDate;
-      if (endDate) searchParams.end_date = endDate;
-      if (status) searchParams.status = status;
+      if (query?.businessId != undefined)
+        searchParams.businessId = query.businessId;
       const result = await client
-        .get(url, { searchParams })
-        .json<AccountingWorkLogWrapper>();
-      return result;
-    } catch (error: unknown) {
-      return handleServiceError(error);
-    }
-  },
-
-  async getTaxes(businessId: string, year: number): Promise<TaxSummaryWrapper> {
-    const client = createAuthenticatedClient();
-    try {
-      const url = API_CONFIG.ACCOUNTANT.GET_TAXES;
-      const searchParams: Record<string, string | number> = {
-        businessId,
-        year,
-      };
-      const result = await client
-        .get(url, { searchParams })
-        .json<TaxSummaryWrapper>();
+        .get(endpoint, { searchParams })
+        .json<GetJobResultsResponseDto>();
       return result;
     } catch (error: unknown) {
       return handleServiceError(error);
@@ -175,49 +110,116 @@ export const AccountantService = {
   },
 
   async cancelJob(
-    businessId: string,
-    taskId: string
-  ): Promise<CancelJobWrapper> {
+    params: CancelJobParams,
+    query?: CancelJobQuery
+  ): Promise<CancelAccountingJobResponseDto> {
     const client = createAuthenticatedClient();
     try {
+      const endpoint = API_CONFIG.ACCOUNTANT.CANCEL_JOB.replace(
+        '{taskId}',
+        encodeURIComponent(params.taskId)
+      );
+      const searchParams: Record<string, string> = {};
+      if (query?.businessId != undefined)
+        searchParams.businessId = query.businessId;
       const result = await client
-        .delete(
-          API_CONFIG.ACCOUNTANT.GET_JOB.replace(
-            '{taskId}',
-            encodeURIComponent(taskId)
-          ),
-          { searchParams: { businessId } }
-        )
-        .json<CancelJobWrapper>();
+        .delete(endpoint, { searchParams })
+        .json<CancelAccountingJobResponseDto>();
       return result;
     } catch (error: unknown) {
       return handleServiceError(error);
     }
   },
 
-  async health(businessId?: string): Promise<AccountantHealthResponse> {
+  async getHistory(
+    params?: GetAccountingHistoryQuery
+  ): Promise<GetAccountingHistoryResponseDto> {
     const client = createAuthenticatedClient();
     try {
-      // Some backends require businessId on all /accountant/* routes
-      const searchParams: Record<string, string> = {};
-      if (businessId) {
-        searchParams.businessId = businessId;
-      }
-      const url = API_CONFIG.ACCOUNTANT.HEALTH;
-
-      const response = await client.get(url, {
-        searchParams:
-          Object.keys(searchParams).length > 0 ? searchParams : undefined,
-      });
-      const result = await response.json<AccountantHealthResponse>();
+      const searchParams: Record<string, string | number> = {};
+      if (params?.businessId != undefined)
+        searchParams.businessId = params.businessId;
+      if (params?.limit != undefined) searchParams.limit = params.limit;
+      const result = await client
+        .get(API_CONFIG.ACCOUNTANT.GET_HISTORY, { searchParams })
+        .json<GetAccountingHistoryResponseDto>();
       return result;
-    } catch {
-      // Return unavailable on any error per API docs
-      return {
-        success: false,
-        service: 'ai-accountant',
-        status: 'unavailable',
-      };
+    } catch (error: unknown) {
+      return handleServiceError(error);
+    }
+  },
+
+  async getWork(
+    params?: GetAllAccountantWorkQuery
+  ): Promise<GetAllAccountantWorkResponseDto> {
+    const client = createAuthenticatedClient();
+    try {
+      const searchParams: Record<string, string> = {};
+      if (params?.businessId != undefined)
+        searchParams.businessId = params.businessId;
+      if (params?.startDate != undefined)
+        searchParams.startDate =
+          params.startDate instanceof Date
+            ? params.startDate.toISOString()
+            : params.startDate;
+      if (params?.endDate != undefined)
+        searchParams.endDate =
+          params.endDate instanceof Date
+            ? params.endDate.toISOString()
+            : params.endDate;
+      if (params?.status != undefined) searchParams.status = params.status;
+      const result = await client
+        .get(API_CONFIG.ACCOUNTANT.GET_WORK, { searchParams })
+        .json<GetAllAccountantWorkResponseDto>();
+      return result;
+    } catch (error: unknown) {
+      return handleServiceError(error);
+    }
+  },
+
+  async getTaxes(
+    params: GetTaxesQuery
+  ): Promise<TunisianTaxSummaryResponseDto> {
+    const client = createAuthenticatedClient();
+    try {
+      const searchParams: Record<string, string | number> = {};
+      if (params.businessId != undefined)
+        searchParams.businessId = params.businessId;
+      if (params.year != undefined) searchParams.year = params.year;
+      const result = await client
+        .get(API_CONFIG.ACCOUNTANT.GET_TAXES, { searchParams })
+        .json<TunisianTaxSummaryResponseDto>();
+      return result;
+    } catch (error: unknown) {
+      return handleServiceError(error);
+    }
+  },
+
+  async calculateTaxes(
+    params: CalculateTaxesQuery
+  ): Promise<CalculateTaxResponseDto> {
+    const client = createAuthenticatedClient();
+    try {
+      const searchParams: Record<string, string | number> = {};
+      if (params.businessId != undefined)
+        searchParams.businessId = params.businessId;
+      if (params.year != undefined) searchParams.year = params.year;
+      const result = await client
+        .post(API_CONFIG.ACCOUNTANT.CALCULATE_TAXES, { searchParams })
+        .json<CalculateTaxResponseDto>();
+      return result;
+    } catch (error: unknown) {
+      return handleServiceError(error);
+    }
+  },
+  async health(): Promise<AccountantHealthResponseDto> {
+    try {
+      const result = await publicClient
+        .get(API_CONFIG.ACCOUNTANT.HEALTH)
+        .json<AccountantHealthResponseDto>();
+      return result;
+    } catch (error: unknown) {
+      return handleServiceError(error);
     }
   },
 };

--- a/lib/services/auth.ts
+++ b/lib/services/auth.ts
@@ -40,6 +40,8 @@ import type {
   TwoFADisableResponse,
   BanUserResponse,
   UnbanUserResponse,
+  UserStripeOnboardingLinkResponse,
+  UserStripeConnectStatusResponse,
 } from '@/types/services';
 import {
   ApiError,
@@ -475,6 +477,30 @@ export const AuthService = {
     try {
       const endpoint = API_CONFIG.AUTH.UNBAN_USER.replace('{id}', userId);
       const result = await client.patch(endpoint).json<UnbanUserResponse>();
+      return result;
+    } catch (error: unknown) {
+      return handleServiceError(error);
+    }
+  },
+
+  async getStripeOnboardingLink(): Promise<UserStripeOnboardingLinkResponse> {
+    const client = createAuthenticatedClient();
+    try {
+      const result = await client
+        .post(API_CONFIG.AUTH.STRIPE_ONBOARDING)
+        .json<UserStripeOnboardingLinkResponse>();
+      return result;
+    } catch (error: unknown) {
+      return handleServiceError(error);
+    }
+  },
+
+  async getStripeConnectStatus(): Promise<UserStripeConnectStatusResponse> {
+    const client = createAuthenticatedClient();
+    try {
+      const result = await client
+        .get(API_CONFIG.AUTH.STRIPE_STATUS)
+        .json<UserStripeConnectStatusResponse>();
       return result;
     } catch (error: unknown) {
       return handleServiceError(error);

--- a/lib/services/invoices.ts
+++ b/lib/services/invoices.ts
@@ -12,6 +12,7 @@ import type {
   InvoiceCheckoutSessionResponse,
   ImportTemplateResponseDto,
   BulkImportInvoicesResponseDto,
+  InvoicePaymentConfirmResponse,
 } from '@/types/services';
 import { createAuthenticatedClient, API_CONFIG } from '@/lib/requests';
 
@@ -257,6 +258,27 @@ export const InvoicesService = {
       const result = await client
         .post(endpoint, { json: payload })
         .json<InvoiceResponse>();
+      return result;
+    } catch (error: unknown) {
+      return handleServiceError(error);
+    }
+  },
+
+  // 8. Confirm Payment (Payment-related method grouped with checkout/mock)
+  async confirmPayment(params: {
+    sessionId: string;
+    receiptId: string;
+  }): Promise<InvoicePaymentConfirmResponse> {
+    const client = createAuthenticatedClient();
+    try {
+      const result = await client
+        .post(API_CONFIG.INVOICES.CONFIRM_PAYMENT, {
+          searchParams: {
+            session_id: params.sessionId,
+            receipt_id: params.receiptId,
+          },
+        })
+        .json<InvoicePaymentConfirmResponse>();
       return result;
     } catch (error: unknown) {
       return handleServiceError(error);

--- a/types/services/accountantResponses.ts
+++ b/types/services/accountantResponses.ts
@@ -1,279 +1,245 @@
-import type { ApiResponse } from './sharedTypes';
-
-// Accounting Job Status Types (API uses lowercase, includes cancelled)
-export type AccountingJobStatus =
+export type AccountantJobStatus =
   | 'pending'
   | 'processing'
   | 'completed'
-  | 'failed'
-  | 'cancelled';
+  | 'cancelled'
+  | 'failed';
 
-// Tax Calculation (matches API docs)
-export interface TaxCalculation {
-  tax_type: string;
-  jurisdiction: string;
-  taxable_amount: number;
-  tax_rate: number;
-  tax_amount: number;
-}
-
-// Anomaly Detected (matches API docs)
-export interface AnomalyDetected {
-  type: string;
-  severity: 'low' | 'medium' | 'high';
-  description: string;
-  affected_transactions?: string[];
-}
-
-// Report from results
-export interface JobReport {
-  report_type: string;
-  generated_at?: string;
-  download_url?: string;
-  data?: Record<string, unknown>;
-}
-
-// Journal Entry Preview
-export interface JournalEntryPreview {
-  date: string;
-  account: string;
-  debit: number;
-  credit: number;
-  description?: string;
-}
-
-// Journal Entry (results)
-export interface JournalEntry {
-  date: string;
-  debit_account: string;
-  credit_account: string;
-  amount: number;
-  description?: string;
-  reference?: string;
-}
-
-// Transaction from results
-export interface Transaction {
-  id: string;
-  date: string;
-  description: string;
-  amount: number;
-  category?: string;
-  account?: string;
-  currency?: string;
-}
-
-// Accounting Job Details (GET /jobs/{taskId}) - unwrapped
-export interface AccountingJobDetails {
-  task_id: string;
-  business_id: string;
-  period_start: string;
-  period_end: string;
-  status: AccountingJobStatus;
-  progress_percent: number;
-  started_at?: string | null;
-  completed_at?: string | null;
-  error_message?: string | null;
-  journal_entries_count?: number;
-  reports_generated?: number;
-}
-
-// Create Accounting Job Response (POST /jobs) - unwrapped
-export interface CreateAccountingJobResponse {
-  task_id: string;
-  status: AccountingJobStatus;
+export interface CreateAccountingJobResponseDto {
   message: string;
-  estimated_completion?: string;
-  business_id?: string;
-  period_start?: string;
-  period_end?: string;
-  created_at?: string;
-}
-
-// Wrapped response aliases using generic ApiResponse<T>
-export type CreateAccountingJobWrapper =
-  ApiResponse<CreateAccountingJobResponse>;
-export type AccountingJobDetailsWrapper = ApiResponse<AccountingJobDetails>;
-export type GetAccountingJobResultsWrapper =
-  ApiResponse<GetAccountingJobResultsResponse>;
-export type CancelJobWrapper = ApiResponse<CancelJobResponse>;
-export type AccountingHistoryWrapper = ApiResponse<AccountingHistoryResponse>;
-export type AccountingWorkLogWrapper = ApiResponse<AccountingWorkLogResponse>;
-export type TaxSummaryWrapper = ApiResponse<TaxSummaryResponse>;
-
-// Job list item with period info (used in list response)
-export interface AccountingJobListItemWithPeriod {
-  task_id: string;
-  period_start: string;
-  period_end: string;
-  status: AccountingJobStatus;
-  progress_percent?: number;
-  started_at?: string | null;
-  completed_at?: string | null;
-  business_id?: string;
-  error_message?: string | null;
-  journal_entries_count?: number;
-  reports_generated?: number;
-}
-
-// List Accounting Jobs Response (GET /jobs) — wrapped with success + meta
-export interface ListAccountingJobsResponse extends ApiResponse<
-  AccountingJobListItemWithPeriod[]
-> {
-  meta: { total: number };
-}
-
-// Get Accounting Job Results Response (GET /jobs/{taskId}/results) - unwrapped
-export interface GetAccountingJobResultsResponse {
-  task_id: string;
-  business_id: string;
-  period_start: string;
-  period_end: string;
-  status: AccountingJobStatus;
-  total_revenue?: number;
-  total_expenses?: number;
-  gross_profit?: number;
-  net_profit?: number;
-  tax_calculations?: TaxCalculation[];
-  ai_insights?: string;
-  recommendations?: string[];
-  anomalies_detected?: AnomalyDetected[];
-  reports?: JobReport[];
-  journal_entries_preview?: JournalEntryPreview[];
-  journal_entries?: JournalEntry[];
-  total_journal_entries?: number;
-  completed_at?: string | null;
-}
-
-// Cancel Job Response (DELETE /jobs/{taskId}) - unwrapped
-export interface CancelJobResponse {
-  task_id: string;
-  status: 'cancelled';
-  message: string;
-  previous_status?: string;
-}
-
-// Accounting History Task
-export interface AccountingHistoryTask {
-  task_id: string;
-  status: AccountingJobStatus;
-  period_start: string;
-  period_end: string;
-  completed_at?: string | null;
-}
-
-// Accounting History Response (GET /business/{businessId}/history) - unwrapped
-export interface AccountingHistoryResponse {
-  business_id: string;
-  tasks: AccountingHistoryTask[];
-}
-
-// Work Log Entry
-export interface WorkLogEntry {
-  date: string;
-  type: string;
-  description: string;
-  user_id?: string;
-  metadata?: Record<string, unknown>;
-}
-
-// Work Log Summary
-export interface WorkLogSummary {
-  total_accounting_periods: number;
-  completed: number;
-  pending: number;
-  processing: number;
-  failed: number;
-  total_journal_entries_generated?: number;
-  total_revenue_processed?: number;
-}
-
-// Accounting Period Detail
-export interface AccountingPeriodDetail {
-  task_id: string;
-  period_start: string;
-  period_end: string;
-  status: AccountingJobStatus;
-  created_at?: string;
-  started_at?: string;
-  completed_at?: string;
-  journal_entries_count?: number;
-  tax_calculations_count?: number;
-  reports_count?: number;
-  has_ai_insights?: boolean;
-  recommendations_count?: number;
-  financial_summary?: {
-    total_revenue?: number;
-    total_expenses?: number;
-    gross_profit?: number;
-    net_profit?: number;
-    accounts_receivable?: number;
-    accounts_payable?: number;
-    cash_position?: number;
+  timestamp: string;
+  job: {
+    taskId: string;
+    status: AccountantJobStatus;
+    message?: string;
+    estimatedCompletion?: string;
   };
 }
 
-// Accounting Work Log Response (GET /business/{businessId}/work) - unwrapped
-export interface AccountingWorkLogResponse {
-  business_id: string;
-  database_name?: string;
-  summary: WorkLogSummary;
-  accounting_periods: AccountingPeriodDetail[];
+export interface AccountantJobSummaryDto {
+  taskId: string;
+  periodStart: string;
+  periodEnd: string;
+  status: AccountantJobStatus;
+  progressPercent?: number;
+  startedAt?: string;
+  completedAt?: string | null;
+  journalEntriesCount?: number;
+  reportsGenerated?: number;
 }
 
-// VAT Breakdown
-export interface VatBreakdown {
-  standard_rate_19_percent?: number;
-  reduced_rate_13_percent?: number;
-  reduced_rate_7_percent?: number;
+export interface ListAccountingJobsResponseDto {
+  message: string;
+  timestamp: string;
+  jobs: AccountantJobSummaryDto[];
+  total: number;
 }
 
-// Monthly Tax Detail
-export interface MonthlyTaxDetail {
-  month: number;
-  period?: string;
-  vat_standard_19?: number;
-  vat_reduced_13?: number;
-  vat_reduced_7?: number;
-  vat_total?: number;
-  taxable_income?: number;
-  corporate_tax_due?: number;
-  withholding_tax?: number;
-  total_tax_liability?: number;
-  due_date?: string;
+export interface GetJobStatusResponseDto {
+  message: string;
+  timestamp: string;
+  job: {
+    taskId: string;
+    businessId?: string;
+    periodStart: string;
+    periodEnd: string;
+    status: AccountantJobStatus;
+    progressPercent: number;
+    startedAt?: string;
+    completedAt?: string | null;
+    journalEntriesCount?: number;
+    reportsGenerated?: number;
+  };
 }
 
-// Tax Calendar Item
-export interface TaxCalendarItem {
-  period: string;
-  due_date: string;
+export interface TaxCalculationDto {
+  taxType: string;
+  jurisdiction?: string;
+  taxableAmount: number;
+  taxRate: number;
+  taxAmount: number;
+  notes?: string;
+}
+
+export interface AnomalyDto {
+  type: string;
+  description: string;
+  severity: 'low' | 'medium' | 'high';
+}
+
+export interface ReportDto {
+  reportType: string;
+  periodStart: string;
+  periodEnd: string;
+  data: Record<string, unknown>;
+}
+
+export interface JournalEntryDto {
+  date?: string;
+  account?: string;
+  debit?: number;
+  credit?: number;
   description?: string;
 }
 
-// Tax Summary Data
-export interface TaxSummaryData {
-  annual_vat_total?: number;
-  annual_corporate_tax?: number;
-  annual_withholding_tax?: number;
-  total_tax_liability?: number;
+export interface GetJobResultsResponseDto {
+  message: string;
+  timestamp: string;
+  results: {
+    taskId: string;
+    businessId?: string;
+    status: AccountantJobStatus;
+    periodStart?: string;
+    periodEnd?: string;
+    totalRevenue?: number;
+    totalExpenses?: number;
+    grossProfit?: number;
+    netProfit?: number;
+    accountsReceivable?: number;
+    accountsPayable?: number;
+    cashPosition?: number;
+    taxCalculations?: TaxCalculationDto[];
+    aiInsights?: string;
+    recommendations?: string[];
+    anomaliesDetected?: AnomalyDto[];
+    reports?: ReportDto[];
+    journalEntriesPreview?: JournalEntryDto[];
+    totalJournalEntries?: number;
+  };
 }
 
-// Tax Summary Response (GET /business/{businessId}/taxes) - unwrapped
-export interface TaxSummaryResponse {
-  business_id: string;
-  business_name?: string;
-  year?: number;
-  currency?: string;
-  summary: TaxSummaryData;
-  vat_breakdown?: VatBreakdown;
-  monthly_details?: MonthlyTaxDetail[];
-  tax_calendar?: TaxCalendarItem[];
-  notes?: string[];
+export interface CancelAccountingJobResponseDto {
+  message: string;
+  timestamp: string;
+  result: {
+    taskId: string;
+    status: AccountantJobStatus;
+    message?: string;
+    previousStatus?: AccountantJobStatus;
+  };
 }
 
-// Health Check Response (kept wrapped)
-export interface AccountantHealthResponse {
+export interface AccountingHistoryTaskDto {
+  taskId: string;
+  periodStart: string;
+  periodEnd: string;
+  status: AccountantJobStatus;
+  completedAt?: string;
+}
+
+export interface GetAccountingHistoryResponseDto {
+  message: string;
+  timestamp: string;
+  businessId: string;
+  tasks: AccountingHistoryTaskDto[];
+}
+
+export interface FinancialSummaryDto {
+  totalRevenue?: number;
+  totalExpenses?: number;
+  grossProfit?: number;
+  netProfit?: number;
+  accountsReceivable?: number;
+  accountsPayable?: number;
+  cashPosition?: number;
+}
+
+export interface AccountantWorkPeriodDto {
+  taskId: string;
+  periodStart: string;
+  periodEnd: string;
+  status: AccountantJobStatus;
+  createdAt?: string;
+  startedAt?: string;
+  completedAt?: string;
+  journalEntriesCount?: number;
+  taxCalculationsCount?: number;
+  reportsCount?: number;
+  hasAiInsights?: boolean;
+  recommendationsCount?: number;
+  financialSummary?: FinancialSummaryDto;
+}
+
+export interface GetAllAccountantWorkResponseDto {
+  message: string;
+  timestamp: string;
+  work: {
+    businessId: string;
+    databaseName?: string;
+    summary?: {
+      totalAccountingPeriods?: number;
+      completed?: number;
+      pending?: number;
+      processing?: number;
+      failed?: number;
+      totalJournalEntriesGenerated?: number;
+      totalRevenueProcessed?: number;
+    };
+    accountingPeriods?: AccountantWorkPeriodDto[];
+  };
+}
+
+export interface MonthlyTaxDetailDto {
+  month: number;
+  period: string;
+  vatStandard19?: number;
+  vatReduced13?: number;
+  vatReduced7?: number;
+  vatTotal?: number;
+  taxableIncome?: number;
+  corporateTaxDue?: number;
+  withholdingTax?: number;
+  totalTaxLiability?: number;
+  dueDate?: string;
+}
+
+export interface TaxCalendarItemDto {
+  period: string;
+  dueDate?: string;
+  description?: string;
+}
+
+export interface TunisianTaxSummaryResponseDto {
+  message: string;
+  timestamp: string;
+  taxes: {
+    businessId: string;
+    businessName?: string;
+    year: number;
+    currency?: string;
+    summary?: {
+      annualVatTotal?: number;
+      annualCorporateTax?: number;
+      annualWithholdingTax?: number;
+      totalTaxLiability?: number;
+    };
+    vatBreakdown?: {
+      standardRate19Percent?: number;
+      reducedRate13Percent?: number;
+      reducedRate7Percent?: number;
+    };
+    monthlyDetails?: MonthlyTaxDetailDto[];
+    taxCalendar?: TaxCalendarItemDto[];
+    notes?: string[];
+  };
+}
+
+export type TaxSummaryDto = TunisianTaxSummaryResponseDto['taxes']['summary'];
+
+export interface CalculateTaxResponseDto {
+  message: string;
+  timestamp: string;
+  result: {
+    businessId: string;
+    businessName?: string;
+    year: number;
+    summary: TaxSummaryDto | undefined;
+    message?: string;
+  };
+}
+
+export interface AccountantHealthResponseDto {
   success: boolean;
   service: string;
-  status: 'available' | 'unavailable';
+  status: 'available' | 'unavailable' | (string & {});
 }

--- a/types/services/accountantSchemas.ts
+++ b/types/services/accountantSchemas.ts
@@ -1,57 +1,99 @@
 import { z } from 'zod';
 
-// Normalize input to camelCase and validate dates
-export const CreateAccountingJobSchema = z.preprocess(
-  (raw) => {
-    if (typeof raw !== 'object' || raw === null) return raw;
-    const obj = raw as Record<string, unknown>;
-    return {
-      businessId: (obj.businessId ?? obj.business_id) as unknown,
-      periodStart: (obj.periodStart ?? obj.period_start) as unknown,
-      periodEnd: (obj.periodEnd ?? obj.period_end) as unknown,
-    };
-  },
-  z
-    .object({
-      businessId: z.string().min(1, 'businessId is required'),
-      periodStart: z
-        .string()
-        .min(1, 'Period start is required')
-        .refine(
-          (s) => !Number.isNaN(Date.parse(s)),
-          'periodStart must be a valid ISO date'
-        ),
-      periodEnd: z
-        .string()
-        .min(1, 'Period end is required')
-        .refine(
-          (s) => !Number.isNaN(Date.parse(s)),
-          'periodEnd must be a valid ISO date'
-        ),
-    })
-    .refine(
-      (val) => {
-        const start = new Date(val.periodStart);
-        const end = new Date(val.periodEnd);
-        return end.getTime() >= start.getTime();
-      },
-      {
-        message: 'periodEnd must be the same or after periodStart',
-        path: ['periodEnd'],
-      }
-    )
-    .refine(
-      (val) => {
-        const start = new Date(val.periodStart);
-        const end = new Date(val.periodEnd);
-        const msInDay = 24 * 60 * 60 * 1000;
-        const diffDays = (end.getTime() - start.getTime()) / msInDay;
-        return diffDays <= 365;
-      },
-      { message: 'Period length must not exceed 365 days', path: ['periodEnd'] }
-    )
-);
+const DateSchema = z.iso
+  .date({ error: 'Invalid ISO date' })
+  .transform((val) => new Date(val));
 
-export type CreateAccountingJobInput = z.infer<
+export const CreateAccountingJobSchema = z
+  .object({
+    businessId: z.string().min(1, 'Business ID is required'),
+    periodStart: DateSchema,
+    periodEnd: DateSchema,
+  })
+  .refine((data) => data.periodEnd.getTime() >= data.periodStart.getTime(), {
+    message: 'Period end must be after or equal to period start',
+    path: ['periodEnd'],
+  });
+
+export const ListAccountingJobsQuerySchema = z.object({
+  businessId: z.string().optional(),
+  limit: z.coerce.number().int().positive().optional(),
+});
+
+export const GetJobStatusParamsSchema = z.object({
+  taskId: z.string().min(1, 'Task ID is required'),
+});
+
+export const GetJobStatusQuerySchema = z.object({
+  businessId: z.string().optional(),
+});
+
+export const CancelJobParamsSchema = z.object({
+  taskId: z.string().min(1, 'Task ID is required'),
+});
+
+export const CancelJobQuerySchema = z.object({
+  businessId: z.string().optional(),
+});
+
+export const GetAccountingHistoryQuerySchema = z.object({
+  businessId: z.string().optional(),
+  limit: z.coerce.number().int().positive().optional(),
+});
+
+export const GetJobResultsParamsSchema = z.object({
+  taskId: z.string().min(1, 'Task ID is required'),
+});
+
+export const GetJobResultsQuerySchema = z.object({
+  businessId: z.string().optional(),
+});
+
+export const GetAllAccountantWorkQuerySchema = z
+  .object({
+    businessId: z.string().optional(),
+    startDate: DateSchema.optional(),
+    endDate: DateSchema.optional(),
+    status: z.string().optional(),
+  })
+  .refine(
+    (data) =>
+      !data.startDate ||
+      !data.endDate ||
+      data.endDate.getTime() >= data.startDate.getTime(),
+    {
+      message: 'End date must be after or equal to start date',
+      path: ['endDate'],
+    }
+  );
+
+export const GetTaxesQuerySchema = z.object({
+  businessId: z.string().optional(),
+  year: z.coerce.number().int().gte(2000).lte(2100).optional(),
+});
+
+export const CalculateTaxesQuerySchema = z.object({
+  businessId: z.string().optional(),
+  year: z.coerce.number().int().gte(2000).lte(2100).optional(),
+});
+
+export type CreateAccountingJobInput = z.input<
   typeof CreateAccountingJobSchema
 >;
+export type ListAccountingJobsQuery = z.infer<
+  typeof ListAccountingJobsQuerySchema
+>;
+export type GetJobStatusParams = z.infer<typeof GetJobStatusParamsSchema>;
+export type GetJobStatusQuery = z.infer<typeof GetJobStatusQuerySchema>;
+export type GetJobResultsParams = z.infer<typeof GetJobResultsParamsSchema>;
+export type GetJobResultsQuery = z.infer<typeof GetJobResultsQuerySchema>;
+export type CancelJobParams = z.infer<typeof CancelJobParamsSchema>;
+export type CancelJobQuery = z.infer<typeof CancelJobQuerySchema>;
+export type GetAccountingHistoryQuery = z.infer<
+  typeof GetAccountingHistoryQuerySchema
+>;
+export type GetAllAccountantWorkQuery = z.infer<
+  typeof GetAllAccountantWorkQuerySchema
+>;
+export type GetTaxesQuery = z.infer<typeof GetTaxesQuerySchema>;
+export type CalculateTaxesQuery = z.infer<typeof CalculateTaxesQuerySchema>;

--- a/types/services/authResponses.ts
+++ b/types/services/authResponses.ts
@@ -128,6 +128,18 @@ export type BanUserResponse = BaseResponse;
 export type UnbanUserResponse = BaseResponse;
 export type TwoFADisableResponse = BaseResponse;
 
+// Stripe Connect (Individual User)
+export interface UserStripeOnboardingLinkResponse {
+  onboardingUrl: string;
+  message: string;
+}
+
+export interface UserStripeConnectStatusResponse {
+  isConnected: boolean;
+  stripeConnectId?: string;
+  message: string;
+}
+
 // OpenAPI compatibility aliases
 export type RegistrationResponseDto = RegisterResponse;
 export type RefreshResponseDto = RefreshTokenResponse;

--- a/types/services/invoicesResponses.ts
+++ b/types/services/invoicesResponses.ts
@@ -138,3 +138,8 @@ export interface InvoiceCheckoutSessionResponse {
   sessionId: string;
   checkoutUrl: string;
 }
+
+export interface InvoicePaymentConfirmResponse {
+  success: boolean;
+  status: 'complete' | 'open' | 'expired' | (string & {});
+}


### PR DESCRIPTION
### TL;DR

Aligns the accountant service, invoice payments, and chatbot UI with updated API contracts, migrating all response/request types from snake_case wrapped responses to camelCase DTOs, and adds Stripe Connect onboarding support for individual users.

### What changed?

**Accountant Service & Types**

- Replaced all legacy `AccountingJobStatus`, wrapped response types (`TaxSummaryWrapper`, `CancelJobWrapper`, etc.), and snake_case field names with new camelCase DTOs (`AccountantJobStatus`, `TunisianTaxSummaryResponseDto`, `CancelAccountingJobResponseDto`, etc.)
- Refactored `AccountantService` method signatures to accept structured query/params objects instead of positional arguments (e.g., `listJobs({ businessId })`, `cancelJob({ taskId }, { businessId })`, `getTaxes({ businessId, year })`)
- Added `calculateTaxes` method and corresponding `CalculateTaxResponseDto` type
- Changed `health()` to use the public client and removed the `businessId` dependency
- Updated `GET_HISTORY` and `GET_WORK` API routes to remove the `{businessId}` path segment
- Added `CALCULATE_TAXES` endpoint to `API_CONFIG`
- Simplified `CreateAccountingJobSchema` and added new Zod schemas for all query/param types

**BusinessAccountant Component**

- Updated all data access to use new camelCase field names (`taskId`, `periodStart`, `periodEnd`, `progressPercent`, etc.)
- Added a `calculateTaxesMutation` with success/error toast handling and query invalidation
- Passed `isCalculating` and `onCalculateTaxes` props down to `TaxSummaryView`
- Removed manual response unwrapping logic throughout
- Wrapped job list `<Table>` in a bordered `<div>` for consistent styling

**JobResultsView**

- Simplified props to accept `GetJobResultsResponseDto['results']` directly, removing union type normalization
- Removed the secondary summary cards (status, completedAt) and consolidated the layout into a 4-column grid
- Replaced structured `AnomalyDetected` objects with plain string rendering
- Removed the reports section
- Wrapped tables in bordered `<div>` containers and removed the `account` column from journal entries preview

**TaxSummaryView**

- Simplified props to accept `TunisianTaxSummaryResponseDto['taxes']` directly
- Added `onCalculateTaxes` callback and `isCalculating` prop, rendering a calculate button with loading state when no tax data is available
- Updated all field references to camelCase (`annualVatTotal`, `vatBreakdown.standardRate19Percent`, `monthlyDetails`, `taxCalendar`, `dueDate`, etc.)
- Wrapped tables in bordered `<div>` containers

**Invoices & Stripe Connect**

- Added `AuthService.getStripeOnboardingLink()` and `AuthService.getStripeConnectStatus()` methods
- Added `UserStripeOnboardingLinkResponse` and `UserStripeConnectStatusResponse` types
- Added a Stripe Connect status card to the Invoices page showing connection state, the Stripe Connect ID, and an onboarding button that opens the Stripe onboarding URL in a new tab
- Added `InvoicesService.confirmPayment()` and `InvoicePaymentConfirmResponse` type
- Added `CONFIRM_PAYMENT`, `PAYMENT_RETURN`, `STRIPE_ONBOARDING`, and `STRIPE_STATUS` to `API_CONFIG`

**Chatbot UI**

- Redesigned the chat header with a neutral background, animated status indicator, and a clear chat button replacing the old badge-based status
- Added `FormattedContent` component to render basic markdown (`**bold**`, `##` headers, `*`/`-` bullet points)
- Added `Avatar` components for both user and bot messages
- Moved the send button inside the input field and styled it with brand colors
- Added a `connecting` i18n key across all three dictionaries (en, fr, ar)

**Dictionaries**

- Added `stripeConnect` translations (title, description, connected, notConnected, connectHint, connectButton, preparingLink, statusError) to en, fr, and ar
- Added `calculating`, `calculateTaxes`, `taxesCalculated`, `calculateTaxesError` keys to the `businessAccountant` section in all three dictionaries
- Added `connecting` key to the chatbot section in all three dictionaries

**BusinessStatistics**

- Replaced the minimal KPI-only skeleton with a full-page skeleton that mirrors the actual layout, including chart placeholders, stats rows, and top-customer list skeletons

### Why make this change?

The backend API was updated to return camelCase DTOs and restructured response envelopes, removing the `{ success, data }` wrapper pattern in favour of flat response objects with named fields. This change brings the frontend type definitions, service layer, and UI components into alignment with the new contract, eliminating manual unwrapping logic and reducing the risk of runtime field-access errors. Stripe Connect onboarding was added to enable individual users to receive invoice payments directly. The chatbot and statistics skeleton improvements enhance perceived performance and readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-click tax calculation with progress state, success/error toasts, and recalculation control.
  * Stripe Connect onboarding: status display and connect flow on Invoices.

* **Improvements**
  * Redesigned job results and tax summary with clearer KPIs, journal previews, anomalies, and updated status labels/icons.
  * Jobs list now shows start dates, progress and entry counts, and improved status text.
  * Chatbot message formatting, header actions, and connection indicator updated.
  * Expanded dashboard loading skeletons and updated AR/EN/FR copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->