### PR TITLE
favicon fix

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,6 +30,9 @@ const notoSansArabic = Noto_Sans_Arabic({
 export const metadata: Metadata = {
   title: 'Accountia',
   description: 'Multi-language accounting and finance management platform',
+  icons: {
+    icon: '/favicon.ico',
+  },
 };
 
 export default async function RootLayout({


### PR DESCRIPTION
### TL;DR

Added favicon configuration to the app metadata.

### What changed?

The app metadata now explicitly references `/favicon.ico` as the site icon, ensuring the favicon is properly linked in the browser tab.

### Why make this change?

Without explicitly defining the `icons` field in the metadata, the favicon may not be consistently picked up by Next.js across all environments and browsers. This ensures the favicon is reliably displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured site favicon for improved browser display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->