### PR TITLE
fixed health endpoint

### DIFF
--- a/components/app/business-accountant/BusinessAccountant.tsx
+++ b/components/app/business-accountant/BusinessAccountant.tsx
@@ -23,6 +23,11 @@ import {
 import { type Locale } from '@/i18n-config';
 import { type Dictionary } from '@/get-dictionary';
 import { AccountantService } from '@/lib/services';
+import type {
+  AccountantHealthResponseDto,
+  ReadinessResponseDto,
+  QuickHealthResponseDto,
+} from '@/types/services';
 import { cn } from '@/lib/utils';
 import { formatDate, dateToISOString } from '@/lib/date-utils';
 import { JobResultsView } from './JobResultsView';
@@ -147,7 +152,7 @@ export default function BusinessAccountant({
     enabled: !!businessId && !!selectedYear,
   });
 
-  const { data: healthData } = useQuery({
+  const { data: healthData } = useQuery<AccountantHealthResponseDto>({
     queryKey: ['accountant-health'],
     queryFn: () => AccountantService.health(),
     retry: 1,
@@ -225,8 +230,12 @@ export default function BusinessAccountant({
 
   const taxSummary = useMemo(() => taxData?.taxes, [taxData]);
   const selectedJobResults = useMemo(() => jobResults?.results, [jobResults]);
-  const isServiceAvailable =
-    healthData?.success && healthData?.status === 'available';
+  const isServiceAvailable = (() => {
+    if (!healthData) return false;
+    const status = (healthData as ReadinessResponseDto | QuickHealthResponseDto)
+      .status;
+    return status === 'ready' || status === 'healthy' || status === 'available';
+  })();
 
   const renderStatusBadge = (status: AccountantJobStatus) => {
     const Icon = statusIcons[status] || Clock; // Fallback to Clock for unknown statuses

--- a/lib/requests.ts
+++ b/lib/requests.ts
@@ -175,6 +175,7 @@ export const API_CONFIG = {
     GET_TAXES: 'accountant/taxes',
     CALCULATE_TAXES: 'accountant/taxes/calculate',
     HEALTH: 'accountant/health',
+    HEALTH_READY: 'accountant/health/ready',
   },
 } as const;
 

--- a/lib/services/accountant.ts
+++ b/lib/services/accountant.ts
@@ -214,10 +214,34 @@ export const AccountantService = {
   },
   async health(): Promise<AccountantHealthResponseDto> {
     try {
-      const result = await publicClient
-        .get(API_CONFIG.ACCOUNTANT.HEALTH)
-        .json<AccountantHealthResponseDto>();
-      return result;
+      // Prefer the deep readiness probe
+      const readyResp = await publicClient.get(
+        API_CONFIG.ACCOUNTANT.HEALTH_READY,
+        {
+          throwHttpErrors: false,
+        }
+      );
+
+      if (readyResp.status === 200) {
+        const body = await readyResp.json<AccountantHealthResponseDto>();
+        return body;
+      }
+
+      if (readyResp.status === 503) {
+        const body = await readyResp
+          .json<AccountantHealthResponseDto>()
+          .catch(() => ({}) as AccountantHealthResponseDto);
+        return body;
+      }
+
+      // Fallback to quick health endpoint
+      const quickResp = await publicClient.get(API_CONFIG.ACCOUNTANT.HEALTH, {
+        throwHttpErrors: false,
+      });
+      const quickBody = await quickResp
+        .json<AccountantHealthResponseDto>()
+        .catch(() => ({}) as AccountantHealthResponseDto);
+      return quickBody;
     } catch (error: unknown) {
       return handleServiceError(error);
     }

--- a/types/services/accountantResponses.ts
+++ b/types/services/accountantResponses.ts
@@ -238,8 +238,32 @@ export interface CalculateTaxResponseDto {
   };
 }
 
-export interface AccountantHealthResponseDto {
-  success: boolean;
-  service: string;
-  status: 'available' | 'unavailable' | (string & {});
+export interface QuickHealthResponseDto {
+  status: 'healthy' | 'ready' | string;
 }
+
+export interface ReadinessChecks {
+  mongodb?: boolean;
+  redis?: boolean;
+  model?: boolean;
+  [key: string]: boolean | undefined;
+}
+
+export interface ModelInfoDto {
+  name?: string;
+  ready?: boolean;
+  [key: string]: unknown;
+}
+
+export interface ReadinessResponseDto {
+  status: 'ready' | 'not_ready' | string;
+  checks?: ReadinessChecks;
+  worker_pid?: number;
+  model_info?: ModelInfoDto;
+  timestamp?: string;
+  [key: string]: unknown;
+}
+
+export type AccountantHealthResponseDto =
+  | QuickHealthResponseDto
+  | ReadinessResponseDto;


### PR DESCRIPTION
### TL;DR

Improved the accountant service health check to use a deep readiness probe with a fallback to the quick health endpoint.

### What changed?

The health check logic now prefers the `/accountant/health/ready` readiness endpoint over the basic `/accountant/health` endpoint. If the readiness probe returns a non-200/503 status, it falls back to the quick health endpoint. The `AccountantHealthResponseDto` type has been replaced with a union of `QuickHealthResponseDto` and `ReadinessResponseDto` to accurately reflect the different response shapes from each endpoint. The `isServiceAvailable` check now accepts `ready`, `healthy`, or `available` as valid statuses to accommodate both endpoint response formats.

### Why make this change?

The previous health check only called the quick health endpoint and relied on a `success` flag and an `available` status string that no longer matched the API's actual response shape. Using the deeper readiness probe provides more reliable service availability information, including dependency checks (MongoDB, Redis, model), while the fallback ensures backward compatibility if the readiness endpoint is not reachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced service availability detection to recognize multiple operational status values for better accuracy
  * Implemented a two-tier health check system with automatic fallback capability for increased reliability
  * Expanded health status reporting with detailed readiness checks and additional service metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->