### PR TITLE
fixing accountant job and taxes

### DIFF
--- a/components/app/business-accountant/BusinessAccountant.tsx
+++ b/components/app/business-accountant/BusinessAccountant.tsx
@@ -13,16 +13,16 @@ import {
   XCircle,
   PlayCircle,
   Calendar as CalendarIcon,
-  Ban,
+  ArrowDown,
+  ArrowUp,
 } from 'lucide-react';
 import { type Locale } from '@/i18n-config';
 import { type Dictionary } from '@/get-dictionary';
 import { AccountantService } from '@/lib/services';
 import type {
   AccountantHealthResponseDto,
-  ReadinessResponseDto,
-  QuickHealthResponseDto,
   GetJobResultsResponseDto,
+  JobSummary,
 } from '@/types/services';
 import { cn } from '@/lib/utils';
 import { formatDate, dateToISOString } from '@/lib/date-utils';
@@ -70,13 +70,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Progress } from '@/components/ui/progress';
 import { toast } from 'sonner';
 
-import type {
-  AccountantJobStatus,
-  CreateAccountingJobInput,
-} from '@/types/services';
+import type { CreateAccountingJobInput } from '@/types/services';
 import { JobResultsView } from './JobResultsView';
 
 interface BusinessAccountantProps {
@@ -85,12 +81,11 @@ interface BusinessAccountantProps {
   dictionary: Dictionary;
 }
 
-const statusIcons: Record<AccountantJobStatus, typeof Clock> = {
+const statusIcons: Record<string, typeof Clock> = {
   pending: Clock,
   processing: Loader2,
   completed: CheckCircle2,
   failed: XCircle,
-  cancelled: Ban,
 };
 
 export default function BusinessAccountant({
@@ -110,6 +105,10 @@ export default function BusinessAccountant({
     new Date().getFullYear()
   );
   const [mounted, setMounted] = useState(false);
+  const [sortConfig, setSortConfig] = useState<{
+    key: 'completedAt' | null;
+    direction: 'asc' | 'desc';
+  }>({ key: 'completedAt', direction: 'desc' });
   useEffect(() => {
     const id = setTimeout(() => setMounted(true), 0);
     return () => clearTimeout(id);
@@ -180,27 +179,11 @@ export default function BusinessAccountant({
     },
   });
 
-  const cancelJobMutation = useMutation({
-    mutationFn: ({ taskId }: { taskId: string }) =>
-      AccountantService.cancelJob({ taskId }, { businessId }),
-    onSuccess: (data) => {
-      const message = data?.result?.message || t.jobCancelled;
-      toast.success(message);
-      queryClient.invalidateQueries({
-        queryKey: ['accountant-jobs', businessId],
-      });
-    },
-    onError: (error: unknown) => {
-      const err = error as Error;
-      toast.error(err.message || t.cancelJobError);
-    },
-  });
-
   const calculateTaxesMutation = useMutation({
     mutationFn: () =>
       AccountantService.calculateTaxes({ businessId, year: selectedYear }),
     onSuccess: (data) => {
-      const message = data.result.message ?? t.taxesCalculated;
+      const message = data.message ?? t.taxesCalculated;
       toast.success(message);
       queryClient.invalidateQueries({
         queryKey: ['accountant-taxes', businessId, selectedYear],
@@ -231,18 +214,25 @@ export default function BusinessAccountant({
   };
 
   const jobs = useMemo(() => {
-    return jobsData?.jobs ?? [];
-  }, [jobsData]);
+    const jobsList = jobsData?.jobs ?? [];
+    if (sortConfig.key === 'completedAt') {
+      return jobsList.toSorted((a, b) => {
+        const dateA = a.completedAt ? new Date(a.completedAt).getTime() : 0;
+        const dateB = b.completedAt ? new Date(b.completedAt).getTime() : 0;
+        return sortConfig.direction === 'asc' ? dateA - dateB : dateB - dateA;
+      });
+    }
+    return jobsList;
+  }, [jobsData, sortConfig]);
 
-  const taxSummary = useMemo(() => taxData?.taxes, [taxData]);
+  const taxSummary = useMemo(() => taxData ?? undefined, [taxData]);
   const isServiceAvailable = (() => {
     if (!healthData) return false;
-    const status = (healthData as ReadinessResponseDto | QuickHealthResponseDto)
-      .status;
+    const status = (healthData as { status?: string })?.status;
     return status === 'ready' || status === 'healthy' || status === 'available';
   })();
 
-  const renderStatusBadge = (status: AccountantJobStatus) => {
+  const renderStatusBadge = (status: JobSummary['status'] | string) => {
     const Icon = statusIcons[status] || Clock; // Fallback to Clock for unknown statuses
     return (
       <Badge
@@ -254,7 +244,7 @@ export default function BusinessAccountant({
         <Icon
           className={cn('h-3 w-3', status === 'processing' && 'animate-spin')}
         />
-        {t.status[status] || status}
+        {t.status?.[status as keyof typeof t.status] || status}
       </Badge>
     );
   };
@@ -407,7 +397,9 @@ export default function BusinessAccountant({
                               {formatDate(job.periodEnd, lang)}
                             </p>
                             <p className="text-muted-foreground text-sm">
-                              {t.status[job.status]}
+                              {t.status?.[
+                                job.status as keyof typeof t.status
+                              ] ?? job.status}
                             </p>
                           </div>
                           <ChevronRight className="text-muted-foreground h-5 w-5" />
@@ -444,11 +436,6 @@ export default function BusinessAccountant({
                     {t.retry}
                   </Button>
                 </div>
-              ) : jobsLoading ? (
-                <div className="space-y-2">
-                  <Skeleton className="h-12 w-full" />
-                  <Skeleton className="h-12 w-full" />
-                </div>
               ) : jobs.length === 0 ? (
                 <div className="text-muted-foreground py-8 text-center">
                   <PlayCircle className="mx-auto mb-2 h-12 w-12 opacity-50" />
@@ -461,8 +448,30 @@ export default function BusinessAccountant({
                       <TableRow>
                         <TableHead>{t.periodColumn}</TableHead>
                         <TableHead>{t.statusColumn}</TableHead>
-                        <TableHead>{t.progressColumn}</TableHead>
                         <TableHead>{t.entriesColumn}</TableHead>
+                        <TableHead
+                          className="cursor-pointer select-none"
+                          onClick={() =>
+                            setSortConfig({
+                              key: 'completedAt',
+                              direction:
+                                sortConfig.key === 'completedAt' &&
+                                sortConfig.direction === 'desc'
+                                  ? 'asc'
+                                  : 'desc',
+                            })
+                          }
+                        >
+                          <span className="flex items-center gap-1">
+                            {t.launchedAtColumn}
+                            {sortConfig.key === 'completedAt' &&
+                              (sortConfig.direction === 'desc' ? (
+                                <ArrowDown className="h-4 w-4" />
+                              ) : (
+                                <ArrowUp className="h-4 w-4" />
+                              ))}
+                          </span>
+                        </TableHead>
                         <TableHead className="text-right">
                           {t.actionsColumn}
                         </TableHead>
@@ -478,43 +487,26 @@ export default function BusinessAccountant({
                                 {formatDate(job.periodEnd, lang)}
                               </p>
                               <p className="text-muted-foreground text-xs">
-                                {job.startedAt
-                                  ? formatDate(job.startedAt, lang)
-                                  : '-'}
+                                {job.reportsGenerated === undefined
+                                  ? '-'
+                                  : `${job.reportsGenerated} report${
+                                      job.reportsGenerated === 1 ? '' : 's'
+                                    }`}
                               </p>
                             </div>
                           </TableCell>
                           <TableCell>{renderStatusBadge(job.status)}</TableCell>
-                          <TableCell>
-                            <div className="w-full max-w-[100px]">
-                              <Progress
-                                value={job.progressPercent ?? 0}
-                                className="h-2"
-                              />
-                              <span className="text-muted-foreground text-xs">
-                                {job.progressPercent ?? 0}%
-                              </span>
-                            </div>
-                          </TableCell>
                           <TableCell>{job.journalEntriesCount}</TableCell>
+                          <TableCell>
+                            {job.status === 'completed' && job.completedAt
+                              ? formatDate(job.completedAt, lang)
+                              : '-'}
+                          </TableCell>
                           <TableCell className="text-right">
                             <div className="flex items-center justify-end gap-2">
                               {job.status === 'pending' ||
                               job.status === 'processing' ? (
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  disabled={cancelJobMutation.isPending}
-                                  onClick={() =>
-                                    cancelJobMutation.mutate({
-                                      taskId: job.taskId,
-                                    })
-                                  }
-                                >
-                                  {cancelJobMutation.isPending
-                                    ? t.cancelling
-                                    : t.cancel}
-                                </Button>
+                                <Loader2 />
                               ) : job.status === 'completed' ? (
                                 <Button
                                   variant="ghost"
@@ -809,7 +801,6 @@ export default function BusinessAccountant({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-      {/* Results are now shown on their own page: /[lang]/business/[businessId]/accountant/results/[taskId] */}
     </div>
   );
 }

--- a/components/app/business-accountant/JobResultsView.tsx
+++ b/components/app/business-accountant/JobResultsView.tsx
@@ -76,6 +76,7 @@ export function JobResultsView({
     recommendations,
     anomaliesDetected,
     reports,
+    journalEntries,
     journalEntriesPreview,
     totalJournalEntries,
   } = results;
@@ -268,10 +269,10 @@ export function JobResultsView({
           <CardContent>
             <ul className="space-y-3">
               {anomaliesDetected.map((anomaly, idx) => (
-                <li key={idx} className="flex items-start gap-2">
+                <li key={idx} className="flex items-center gap-2">
                   <span
                     className={cn(
-                      'mt-0.5 h-2 w-2 shrink-0 rounded-full',
+                      'h-2 w-2 shrink-0 rounded-full',
                       anomaly.severity === 'high'
                         ? 'bg-red-500'
                         : anomaly.severity === 'medium'
@@ -280,9 +281,8 @@ export function JobResultsView({
                     )}
                   />
                   <div>
-                    <span className="font-medium">{anomaly.type}:</span>{' '}
                     <span className="text-muted-foreground">
-                      {anomaly.description}
+                      {anomaly.detail}
                     </span>
                   </div>
                 </li>
@@ -292,36 +292,90 @@ export function JobResultsView({
         </Card>
       )}
 
-      {reports && reports.length > 0 && (
-        <Card>
-          <CardHeader className="pb-3">
-            <CardTitle className="flex items-center gap-2">
-              <FileText className="h-5 w-5" />
-              {t.reports}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul className="space-y-3">
-              {reports.map((report, idx) => (
-                <li key={idx} className="rounded-md border p-3">
-                  <p className="font-medium capitalize">
-                    {(report.reportType ?? '').replaceAll('_', ' ')}
-                  </p>
-                  <p className="text-muted-foreground text-sm">
-                    {formatDate(report.periodStart, lang)} -{' '}
-                    {formatDate(report.periodEnd, lang)}
-                  </p>
-                </li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-      )}
+      {reports &&
+        reports.some(
+          (r) =>
+            r.reportType ||
+            r.periodStart ||
+            r.periodEnd ||
+            r.data?.revenue !== undefined ||
+            r.data?.gross_profit !== undefined
+        ) && (
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2">
+                <FileText className="h-5 w-5" />
+                {t.reports}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-3">
+                {reports
+                  .filter(
+                    (r) =>
+                      r.reportType ||
+                      r.periodStart ||
+                      r.periodEnd ||
+                      r.data?.revenue !== undefined ||
+                      r.data?.gross_profit !== undefined
+                  )
+                  .map((report, idx) => (
+                    <li key={idx} className="rounded-md border p-3">
+                      <div className="flex flex-col gap-1">
+                        {report.reportType && (
+                          <p className="font-medium capitalize">
+                            {report.reportType.replaceAll('_', ' ')}
+                          </p>
+                        )}
+                        {(report.periodStart || report.periodEnd) && (
+                          <p className="text-muted-foreground text-sm">
+                            {report.periodStart &&
+                              formatDate(report.periodStart, lang)}
+                            {report.periodStart && report.periodEnd && ' - '}
+                            {report.periodEnd &&
+                              formatDate(report.periodEnd, lang)}
+                          </p>
+                        )}
+                        {report.data &&
+                          (report.data.revenue !== undefined ||
+                            report.data.gross_profit !== undefined) && (
+                            <div className="grid grid-cols-2 gap-2 text-sm">
+                              {report.data.revenue !== undefined && (
+                                <div>
+                                  <span className="text-muted-foreground">
+                                    {t.revenue}:
+                                  </span>{' '}
+                                  <span className="font-medium">
+                                    {formatCurrency(report.data.revenue)}
+                                  </span>
+                                </div>
+                              )}
+                              {report.data.gross_profit !== undefined && (
+                                <div>
+                                  <span className="text-muted-foreground">
+                                    {t.grossProfit}:
+                                  </span>{' '}
+                                  <span className="font-medium">
+                                    {formatCurrency(report.data.gross_profit)}
+                                  </span>
+                                </div>
+                              )}
+                            </div>
+                          )}
+                      </div>
+                    </li>
+                  ))}
+              </ul>
+            </CardContent>
+          </Card>
+        )}
 
-      {journalEntriesPreview && journalEntriesPreview.length > 0 && (
+      {journalEntries && journalEntries.length > 0 && (
         <Card>
           <CardHeader>
-            <CardTitle>{t.journalEntriesPreview}</CardTitle>
+            <CardTitle>
+              {t.journalEntries} ({journalEntries.length})
+            </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="rounded-md border">
@@ -329,22 +383,24 @@ export function JobResultsView({
                 <TableHeader>
                   <TableRow>
                     <TableHead>{t.date}</TableHead>
+                    <TableHead>{t.account}</TableHead>
                     <TableHead>{t.descriptionColumn}</TableHead>
                     <TableHead className="text-right">{t.debit}</TableHead>
                     <TableHead className="text-right">{t.credit}</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {journalEntriesPreview.map((je, idx) => (
+                  {journalEntries.map((je, idx) => (
                     <TableRow key={idx}>
                       <TableCell>
                         {je.date ? formatDate(je.date, lang) : '-'}
                       </TableCell>
+                      <TableCell className="text-sm">{je.account}</TableCell>
                       <TableCell>
                         {je.description}
-                        {je.account && (
+                        {je.invoiceId && (
                           <span className="text-muted-foreground ml-1 text-xs">
-                            ({je.account})
+                            ({t.invoicePrefix}: {je.invoiceId})
                           </span>
                         )}
                       </TableCell>
@@ -366,6 +422,57 @@ export function JobResultsView({
           </CardContent>
         </Card>
       )}
+
+      {(!journalEntries || journalEntries.length === 0) &&
+        journalEntriesPreview &&
+        journalEntriesPreview.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle>{t.journalEntriesPreview}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>{t.date}</TableHead>
+                      <TableHead>{t.descriptionColumn}</TableHead>
+                      <TableHead className="text-right">{t.debit}</TableHead>
+                      <TableHead className="text-right">{t.credit}</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {journalEntriesPreview.map((je, idx) => (
+                      <TableRow key={idx}>
+                        <TableCell>
+                          {je.date ? formatDate(je.date, lang) : '-'}
+                        </TableCell>
+                        <TableCell>
+                          {je.description}
+                          {je.account && (
+                            <span className="text-muted-foreground ml-1 text-xs">
+                              ({je.account})
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {je.debit === undefined
+                            ? '-'
+                            : formatCurrency(je.debit)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {je.credit === undefined
+                            ? '-'
+                            : formatCurrency(je.credit)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
       {recommendations && recommendations.length > 0 && (
         <Card>

--- a/components/app/business-accountant/TaxSummaryView.tsx
+++ b/components/app/business-accountant/TaxSummaryView.tsx
@@ -21,10 +21,13 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import type { TunisianTaxSummaryResponseDto } from '@/types/services';
+import type {
+  TunisianTaxSummaryResponseDto,
+  TaxBreakdown,
+} from '@/types/services';
 
 interface TaxSummaryViewProps {
-  taxData: TunisianTaxSummaryResponseDto['taxes'] | undefined;
+  taxData: TunisianTaxSummaryResponseDto | undefined;
   t: Dictionary['pages']['businessAccountant'];
   lang: Locale;
   isLoading: boolean;
@@ -84,11 +87,46 @@ export function TaxSummaryView({
     );
   }
 
-  const currency = taxData.currency ?? 'TND';
-  const summary = taxData.summary ?? {};
-  const vatBreakdown = taxData.vatBreakdown ?? {};
-  const monthlyDetails = taxData.monthlyDetails ?? [];
-  const taxCalendar = taxData.taxCalendar ?? [];
+  const currency = 'TND';
+  const breakdown: Partial<TaxBreakdown> = taxData?.taxBreakdown ?? {};
+
+  type VatBreakdownView = {
+    standardRate19Percent?: number;
+    reducedRate13Percent?: number;
+    reducedRate7Percent?: number;
+  };
+
+  const vatBreakdown: VatBreakdownView = {
+    standardRate19Percent: breakdown.vat_standard_19 ?? 0,
+    reducedRate13Percent: breakdown.vat_reduced_13 ?? 0,
+    reducedRate7Percent: breakdown.vat_reduced_7 ?? 0,
+  };
+
+  type TaxCalendarItem = {
+    period?: string;
+    description?: string;
+    dueDate?: string;
+  };
+  const rawTaxCalendar = (taxData?.analysis as Record<string, unknown>)
+    ?.taxCalendar;
+  const taxCalendar: TaxCalendarItem[] = Array.isArray(rawTaxCalendar)
+    ? rawTaxCalendar
+    : [];
+
+  type MonthlyDetail = {
+    period?: string;
+    month?: string;
+    vatTotal?: number;
+    corporateTaxDue?: number;
+    withholdingTax?: number;
+    totalTaxLiability?: number;
+    dueDate?: string;
+  };
+  const rawMonthlyDetails = (taxData?.analysis as Record<string, unknown>)
+    ?.monthlyDetails;
+  const monthlyDetails: MonthlyDetail[] = Array.isArray(rawMonthlyDetails)
+    ? rawMonthlyDetails
+    : [];
 
   return (
     <div className="space-y-4">
@@ -116,29 +154,13 @@ export function TaxSummaryView({
         </div>
       )}
 
-      {/* Tax Summary Cards */}
+      {/* Tax breakdown summary (from backend `taxBreakdown`) */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>{t.annualVat}</CardDescription>
-            <CardTitle className="text-2xl">
-              {formatCurrency(summary.annualVatTotal ?? 0, currency)}
-            </CardTitle>
-          </CardHeader>
-        </Card>
         <Card>
           <CardHeader className="pb-2">
             <CardDescription>{t.corporateTax}</CardDescription>
             <CardTitle className="text-2xl">
-              {formatCurrency(summary.annualCorporateTax ?? 0, currency)}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>{t.withholdingTax}</CardDescription>
-            <CardTitle className="text-2xl">
-              {formatCurrency(summary.annualWithholdingTax ?? 0, currency)}
+              {formatCurrency(breakdown.corporate_tax_due ?? 0, currency)}
             </CardTitle>
           </CardHeader>
         </Card>
@@ -146,7 +168,23 @@ export function TaxSummaryView({
           <CardHeader className="pb-2">
             <CardDescription>{t.totalLiability}</CardDescription>
             <CardTitle className="text-2xl">
-              {formatCurrency(summary.totalTaxLiability ?? 0, currency)}
+              {formatCurrency(breakdown.total_tax_liability ?? 0, currency)}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t.vatBreakdown}</CardDescription>
+            <CardTitle className="text-2xl">
+              {formatCurrency(breakdown.vat_total ?? 0, currency)}
+            </CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>{t.withholdingTax}</CardDescription>
+            <CardTitle className="text-2xl">
+              {formatCurrency(breakdown.withholding_tax ?? 0, currency)}
             </CardTitle>
           </CardHeader>
         </Card>

--- a/dictionaries/ar.json
+++ b/dictionaries/ar.json
@@ -799,8 +799,7 @@
         "pending": "معلق",
         "processing": "قيد المعالجة",
         "completed": "مكتمل",
-        "failed": "فاشل",
-        "cancelled": "ملغى"
+        "failed": "فاشل"
       },
       "overviewTitle": "نظرة عامة",
       "overviewDescription": "اختر مهمة مكتملة لعرض النتائج",
@@ -812,6 +811,7 @@
       "statusColumn": "الحالة",
       "progressColumn": "التقدم",
       "entriesColumn": "القيود",
+      "launchedAtColumn": "تاريخ الإطلاق",
       "actionsColumn": "الإجراءات",
       "viewResults": "عرض النتائج",
       "createJobDialog": {
@@ -852,8 +852,7 @@
       "dueColumn": "الاستحقاق",
       "retry": "إعادة المحاولة",
       "cancelling": "جارٍ الإلغاء...",
-      "jobCancelled": "تم إلغاء المهمة بنجاح",
-      "cancelJobError": "فشل في إلغاء المهمة",
+
       "grossProfit": "الربح الإجمالي",
       "totalJournalEntries": "إجمالي القيود",
       "statusLabel": "الحالة",
@@ -867,6 +866,8 @@
       "anomalies": "شذوذات",
       "download": "تنزيل",
       "journalEntriesPreview": "معاينة القيود",
+      "journalEntries": "القيود المحاسبية",
+      "jobId": "معرف المهمة",
       "date": "التاريخ",
       "account": "الحساب",
       "debit": "مدين",
@@ -878,7 +879,9 @@
       "accountsReceivable": "الذمم المدينة",
       "accountsPayable": "الذمم الدائنة",
       "cashPosition": "الموقف النقدي",
-      "reports": "التقارير"
+      "reports": "التقارير",
+      "revenue": "الإيراد",
+      "invoicePrefix": "فات"
     },
     "businessProducts": {
       "title": "المنتجات",

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -807,8 +807,7 @@
         "pending": "Pending",
         "processing": "Processing",
         "completed": "Completed",
-        "failed": "Failed",
-        "cancelled": "Cancelled"
+        "failed": "Failed"
       },
       "overviewTitle": "Overview",
       "overviewDescription": "Select a completed job to view results",
@@ -820,6 +819,7 @@
       "statusColumn": "Status",
       "progressColumn": "Progress",
       "entriesColumn": "Entries",
+      "launchedAtColumn": "Launched At",
       "actionsColumn": "Actions",
       "viewResults": "View Results",
       "createJobDialog": {
@@ -860,8 +860,7 @@
       "dueColumn": "Due",
       "retry": "Retry",
       "cancelling": "Cancelling...",
-      "jobCancelled": "Job cancelled successfully",
-      "cancelJobError": "Failed to cancel job",
+
       "grossProfit": "Gross Profit",
       "totalJournalEntries": "Total journal entries",
       "statusLabel": "Status",
@@ -875,6 +874,8 @@
       "anomalies": "Anomalies",
       "download": "Download",
       "journalEntriesPreview": "Journal Entries Preview",
+      "journalEntries": "Journal Entries",
+      "jobId": "Job ID",
       "date": "Date",
       "account": "Account",
       "debit": "Debit",
@@ -886,7 +887,9 @@
       "accountsReceivable": "Accounts Receivable",
       "accountsPayable": "Accounts Payable",
       "cashPosition": "Cash Position",
-      "reports": "Reports"
+      "reports": "Reports",
+      "revenue": "Revenue",
+      "invoicePrefix": "Inv"
     },
     "businessProducts": {
       "title": "Products",

--- a/dictionaries/fr.json
+++ b/dictionaries/fr.json
@@ -807,8 +807,7 @@
         "pending": "En attente",
         "processing": "En cours",
         "completed": "Terminé",
-        "failed": "Échoué",
-        "cancelled": "Annulé"
+        "failed": "Échoué"
       },
       "overviewTitle": "Vue d'ensemble",
       "overviewDescription": "Sélectionnez une tâche terminée pour voir les résultats",
@@ -820,6 +819,7 @@
       "statusColumn": "Statut",
       "progressColumn": "Progression",
       "entriesColumn": "Écritures",
+      "launchedAtColumn": "Lancé le",
       "actionsColumn": "Actions",
       "viewResults": "Voir les résultats",
       "createJobDialog": {
@@ -860,8 +860,7 @@
       "dueColumn": "Échéance",
       "retry": "Réessayer",
       "cancelling": "Annulation...",
-      "jobCancelled": "Tâche annulée avec succès",
-      "cancelJobError": "Échec de l'annulation de la tâche",
+
       "grossProfit": "Bénéfice brut",
       "totalJournalEntries": "Total des écritures",
       "statusLabel": "Statut",
@@ -875,6 +874,8 @@
       "anomalies": "Anomalies",
       "download": "Télécharger",
       "journalEntriesPreview": "Aperçu des écritures",
+      "journalEntries": "Écritures comptables",
+      "jobId": "ID de la tâche",
       "date": "Date",
       "account": "Compte",
       "debit": "Débit",
@@ -886,7 +887,9 @@
       "accountsReceivable": "Créances clients",
       "accountsPayable": "Dettes fournisseurs",
       "cashPosition": "Position de trésorerie",
-      "reports": "Rapports"
+      "reports": "Rapports",
+      "revenue": "Revenu",
+      "invoicePrefix": "Fact"
     },
     "businessProducts": {
       "title": "Produits",

--- a/lib/requests.ts
+++ b/lib/requests.ts
@@ -168,14 +168,10 @@ export const API_CONFIG = {
     CREATE_JOB: 'accountant/jobs',
     LIST_JOBS: 'accountant/jobs',
     GET_JOB: 'accountant/jobs/{taskId}',
-    CANCEL_JOB: 'accountant/jobs/{taskId}',
-    GET_JOB_RESULTS: 'accountant/jobs/{taskId}/results',
-    GET_HISTORY: 'accountant/history',
-    GET_WORK: 'accountant/work',
-    GET_TAXES: 'accountant/taxes',
-    CALCULATE_TAXES: 'accountant/taxes/calculate',
+    GET_JOB_RESULTS: 'accountant/jobs/{taskId}',
+    GET_TAXES: 'accountant/taxes/{year}',
+    CALCULATE_TAXES: 'accountant/taxes/{year}',
     HEALTH: 'accountant/health',
-    HEALTH_READY: 'accountant/health/ready',
   },
 } as const;
 

--- a/lib/services/accountant.ts
+++ b/lib/services/accountant.ts
@@ -1,35 +1,21 @@
 import type {
   CreateAccountingJobInput,
   ListAccountingJobsQuery,
-  GetJobStatusParams,
-  GetJobStatusQuery,
   GetJobResultsParams,
   GetJobResultsQuery,
-  CancelJobParams,
-  CancelJobQuery,
-  GetAccountingHistoryQuery,
-  GetAllAccountantWorkQuery,
   GetTaxesQuery,
   CalculateTaxesQuery,
 } from '@/types/services';
 import type {
   CreateAccountingJobResponseDto,
   ListAccountingJobsResponseDto,
-  GetJobStatusResponseDto,
   GetJobResultsResponseDto,
-  CancelAccountingJobResponseDto,
-  GetAccountingHistoryResponseDto,
-  GetAllAccountantWorkResponseDto,
   TunisianTaxSummaryResponseDto,
   CalculateTaxResponseDto,
   AccountantHealthResponseDto,
 } from '@/types/services';
 
-import {
-  createAuthenticatedClient,
-  publicClient,
-  API_CONFIG,
-} from '@/lib/requests';
+import { createAuthenticatedClient, API_CONFIG } from '@/lib/requests';
 import { handleServiceError } from '@/lib/services/service-error';
 
 export const AccountantService = {
@@ -53,8 +39,11 @@ export const AccountantService = {
     const client = createAuthenticatedClient();
     try {
       const searchParams: Record<string, string | number> = {};
-      if (params?.businessId != undefined)
-        searchParams.businessId = params.businessId;
+      if (!params?.businessId) {
+        throw new Error('businessId is required for listing jobs');
+      }
+      searchParams.businessId = params.businessId as string;
+      if (params?.status != undefined) searchParams.status = params.status;
       if (params?.limit != undefined) searchParams.limit = params.limit;
       const result = await client
         .get(API_CONFIG.ACCOUNTANT.LIST_JOBS, { searchParams })
@@ -65,27 +54,9 @@ export const AccountantService = {
     }
   },
 
-  async getJobStatus(
-    params: GetJobStatusParams,
-    query?: GetJobStatusQuery
-  ): Promise<GetJobStatusResponseDto> {
-    const client = createAuthenticatedClient();
-    try {
-      const endpoint = API_CONFIG.ACCOUNTANT.GET_JOB.replace(
-        '{taskId}',
-        encodeURIComponent(params.taskId)
-      );
-      const searchParams: Record<string, string> = {};
-      if (query?.businessId != undefined)
-        searchParams.businessId = query.businessId;
-      const result = await client
-        .get(endpoint, { searchParams })
-        .json<GetJobStatusResponseDto>();
-      return result;
-    } catch (error: unknown) {
-      return handleServiceError(error);
-    }
-  },
+  // The backend exposes a single GET /accountant/jobs/:taskId route
+  // which returns either job status while processing or full results
+  // when completed. Use `getJobResults` for that purpose.
 
   async getJobResults(
     params: GetJobResultsParams,
@@ -98,79 +69,14 @@ export const AccountantService = {
         encodeURIComponent(params.taskId)
       );
       const searchParams: Record<string, string> = {};
-      if (query?.businessId != undefined)
+      if (query?.businessId == undefined) {
+        throw new Error('businessId is required for getting job results');
+      } else {
         searchParams.businessId = query.businessId;
+      }
       const result = await client
         .get(endpoint, { searchParams })
         .json<GetJobResultsResponseDto>();
-      return result;
-    } catch (error: unknown) {
-      return handleServiceError(error);
-    }
-  },
-
-  async cancelJob(
-    params: CancelJobParams,
-    query?: CancelJobQuery
-  ): Promise<CancelAccountingJobResponseDto> {
-    const client = createAuthenticatedClient();
-    try {
-      const endpoint = API_CONFIG.ACCOUNTANT.CANCEL_JOB.replace(
-        '{taskId}',
-        encodeURIComponent(params.taskId)
-      );
-      const searchParams: Record<string, string> = {};
-      if (query?.businessId != undefined)
-        searchParams.businessId = query.businessId;
-      const result = await client
-        .delete(endpoint, { searchParams })
-        .json<CancelAccountingJobResponseDto>();
-      return result;
-    } catch (error: unknown) {
-      return handleServiceError(error);
-    }
-  },
-
-  async getHistory(
-    params?: GetAccountingHistoryQuery
-  ): Promise<GetAccountingHistoryResponseDto> {
-    const client = createAuthenticatedClient();
-    try {
-      const searchParams: Record<string, string | number> = {};
-      if (params?.businessId != undefined)
-        searchParams.businessId = params.businessId;
-      if (params?.limit != undefined) searchParams.limit = params.limit;
-      const result = await client
-        .get(API_CONFIG.ACCOUNTANT.GET_HISTORY, { searchParams })
-        .json<GetAccountingHistoryResponseDto>();
-      return result;
-    } catch (error: unknown) {
-      return handleServiceError(error);
-    }
-  },
-
-  async getWork(
-    params?: GetAllAccountantWorkQuery
-  ): Promise<GetAllAccountantWorkResponseDto> {
-    const client = createAuthenticatedClient();
-    try {
-      const searchParams: Record<string, string> = {};
-      if (params?.businessId != undefined)
-        searchParams.businessId = params.businessId;
-      if (params?.startDate != undefined)
-        searchParams.startDate =
-          params.startDate instanceof Date
-            ? params.startDate.toISOString()
-            : params.startDate;
-      if (params?.endDate != undefined)
-        searchParams.endDate =
-          params.endDate instanceof Date
-            ? params.endDate.toISOString()
-            : params.endDate;
-      if (params?.status != undefined) searchParams.status = params.status;
-      const result = await client
-        .get(API_CONFIG.ACCOUNTANT.GET_WORK, { searchParams })
-        .json<GetAllAccountantWorkResponseDto>();
       return result;
     } catch (error: unknown) {
       return handleServiceError(error);
@@ -182,12 +88,19 @@ export const AccountantService = {
   ): Promise<TunisianTaxSummaryResponseDto> {
     const client = createAuthenticatedClient();
     try {
-      const searchParams: Record<string, string | number> = {};
-      if (params.businessId != undefined)
-        searchParams.businessId = params.businessId;
-      if (params.year != undefined) searchParams.year = params.year;
+      if (!params.businessId)
+        throw new Error('businessId is required for getting taxes');
+      if (params.year == undefined)
+        throw new Error('year is required for getting taxes');
+      const endpoint = API_CONFIG.ACCOUNTANT.GET_TAXES.replace(
+        '{year}',
+        encodeURIComponent(String(params.year))
+      );
+      const searchParams: Record<string, string | number> = {
+        businessId: params.businessId as string,
+      };
       const result = await client
-        .get(API_CONFIG.ACCOUNTANT.GET_TAXES, { searchParams })
+        .get(endpoint, { searchParams })
         .json<TunisianTaxSummaryResponseDto>();
       return result;
     } catch (error: unknown) {
@@ -200,12 +113,19 @@ export const AccountantService = {
   ): Promise<CalculateTaxResponseDto> {
     const client = createAuthenticatedClient();
     try {
-      const searchParams: Record<string, string | number> = {};
-      if (params.businessId != undefined)
-        searchParams.businessId = params.businessId;
-      if (params.year != undefined) searchParams.year = params.year;
+      if (!params.businessId)
+        throw new Error('businessId is required for calculating taxes');
+      if (params.year == undefined)
+        throw new Error('year is required for calculating taxes');
+      const endpoint = API_CONFIG.ACCOUNTANT.CALCULATE_TAXES.replace(
+        '{year}',
+        encodeURIComponent(String(params.year))
+      );
+      const searchParams: Record<string, string | number> = {
+        businessId: params.businessId as string,
+      };
       const result = await client
-        .post(API_CONFIG.ACCOUNTANT.CALCULATE_TAXES, { searchParams })
+        .post(endpoint, { searchParams })
         .json<CalculateTaxResponseDto>();
       return result;
     } catch (error: unknown) {
@@ -213,35 +133,15 @@ export const AccountantService = {
     }
   },
   async health(): Promise<AccountantHealthResponseDto> {
+    const client = createAuthenticatedClient();
     try {
-      // Prefer the deep readiness probe
-      const readyResp = await publicClient.get(
-        API_CONFIG.ACCOUNTANT.HEALTH_READY,
-        {
-          throwHttpErrors: false,
-        }
-      );
-
-      if (readyResp.status === 200) {
-        const body = await readyResp.json<AccountantHealthResponseDto>();
-        return body;
-      }
-
-      if (readyResp.status === 503) {
-        const body = await readyResp
-          .json<AccountantHealthResponseDto>()
-          .catch(() => ({}) as AccountantHealthResponseDto);
-        return body;
-      }
-
-      // Fallback to quick health endpoint
-      const quickResp = await publicClient.get(API_CONFIG.ACCOUNTANT.HEALTH, {
+      const resp = await client.get(API_CONFIG.ACCOUNTANT.HEALTH, {
         throwHttpErrors: false,
       });
-      const quickBody = await quickResp
+      const body = await resp
         .json<AccountantHealthResponseDto>()
         .catch(() => ({}) as AccountantHealthResponseDto);
-      return quickBody;
+      return body;
     } catch (error: unknown) {
       return handleServiceError(error);
     }

--- a/types/services/accountantResponses.ts
+++ b/types/services/accountantResponses.ts
@@ -1,269 +1,164 @@
-export type AccountantJobStatus =
-  | 'pending'
-  | 'processing'
-  | 'completed'
-  | 'cancelled'
-  | 'failed';
+/**
+ * Minimal interfaces for AI Accountant responses — shaped from sample payloads.
+ * Keep these compact and only include fields we actually use.
+ */
 
-export interface CreateAccountingJobResponseDto {
+import { type BaseResponse } from './sharedTypes';
+
+export interface CreateJobResponse {
+  businessId: string;
+  estimatedSeconds: number;
   message: string;
-  timestamp: string;
-  job: {
-    taskId: string;
-    status: AccountantJobStatus;
-    message?: string;
-    estimatedCompletion?: string;
-  };
+  status: string;
+  taskId: string;
 }
 
-export interface AccountantJobSummaryDto {
+export interface JobSummary {
   taskId: string;
+  status: string;
+  journalEntriesCount: number;
+  reportsGenerated: number;
+  progressPercent: number;
   periodStart: string;
   periodEnd: string;
-  status: AccountantJobStatus;
-  progressPercent?: number;
-  startedAt?: string;
-  completedAt?: string | null;
-  journalEntriesCount?: number;
-  reportsGenerated?: number;
+  completedAt: string;
 }
 
-export interface ListAccountingJobsResponseDto {
-  message: string;
-  timestamp: string;
-  jobs: AccountantJobSummaryDto[];
-  total: number;
+export interface JobsListResponse {
+  businessId: string;
+  jobs: JobSummary[];
 }
 
-export interface GetJobStatusResponseDto {
-  message: string;
-  timestamp: string;
-  job: {
-    taskId: string;
-    businessId?: string;
-    periodStart: string;
-    periodEnd: string;
-    status: AccountantJobStatus;
-    progressPercent: number;
-    startedAt?: string;
-    completedAt?: string | null;
-    journalEntriesCount?: number;
-    reportsGenerated?: number;
+export interface JournalEntry {
+  account: string;
+  credit: number;
+  date: string;
+  debit: number;
+  description: string;
+  invoiceId: string;
+}
+
+export interface Report {
+  reportType: string;
+  periodStart?: string;
+  periodEnd?: string;
+  data?: {
+    gross_profit?: number;
+    revenue?: number;
   };
 }
 
-export interface TaxCalculationDto {
+export interface TaxCalculation {
   taxType: string;
-  jurisdiction?: string;
+  jurisdiction: string;
   taxableAmount: number;
   taxRate: number;
   taxAmount: number;
-  notes?: string;
+  notes: string;
 }
 
-export interface AnomalyDto {
-  type: string;
-  description: string;
-  severity: 'low' | 'medium' | 'high';
-}
-
-export interface ReportDto {
-  reportType: string;
-  periodStart: string;
-  periodEnd: string;
-  data: Record<string, unknown>;
-}
-
-export interface JournalEntryDto {
-  date?: string;
-  account?: string;
-  debit?: number;
-  credit?: number;
-  description?: string;
-}
-
-export interface GetJobResultsResponseDto {
-  message: string;
-  timestamp: string;
-  results: {
-    taskId: string;
-    businessId?: string;
-    status: AccountantJobStatus;
-    periodStart?: string;
-    periodEnd?: string;
-    totalRevenue?: number;
-    totalExpenses?: number;
-    grossProfit?: number;
-    netProfit?: number;
-    accountsReceivable?: number;
-    accountsPayable?: number;
-    cashPosition?: number;
-    taxCalculations?: TaxCalculationDto[];
-    aiInsights?: string;
-    recommendations?: string[];
-    anomaliesDetected?: AnomalyDto[];
-    reports?: ReportDto[];
-    journalEntriesPreview?: JournalEntryDto[];
-    totalJournalEntries?: number;
-  };
-}
-
-export interface CancelAccountingJobResponseDto {
-  message: string;
-  timestamp: string;
-  result: {
-    taskId: string;
-    status: AccountantJobStatus;
-    message?: string;
-    previousStatus?: AccountantJobStatus;
-  };
-}
-
-export interface AccountingHistoryTaskDto {
+export interface AccountingResults {
   taskId: string;
-  periodStart: string;
-  periodEnd: string;
-  status: AccountantJobStatus;
-  completedAt?: string;
-}
-
-export interface GetAccountingHistoryResponseDto {
-  message: string;
-  timestamp: string;
   businessId: string;
-  tasks: AccountingHistoryTaskDto[];
-}
-
-export interface FinancialSummaryDto {
-  totalRevenue?: number;
-  totalExpenses?: number;
-  grossProfit?: number;
-  netProfit?: number;
-  accountsReceivable?: number;
-  accountsPayable?: number;
-  cashPosition?: number;
-}
-
-export interface AccountantWorkPeriodDto {
-  taskId: string;
+  status: string;
   periodStart: string;
   periodEnd: string;
-  status: AccountantJobStatus;
-  createdAt?: string;
-  startedAt?: string;
-  completedAt?: string;
-  journalEntriesCount?: number;
-  taxCalculationsCount?: number;
-  reportsCount?: number;
-  hasAiInsights?: boolean;
-  recommendationsCount?: number;
-  financialSummary?: FinancialSummaryDto;
+  totalRevenue: number;
+  totalExpenses: number;
+  grossProfit: number;
+  netProfit: number;
+  accountsReceivable: number;
+  accountsPayable: number;
+  cashPosition: number;
+  taxCalculations: TaxCalculation[];
+  aiInsights: string;
+  recommendations: string[];
+  anomaliesDetected: Array<{
+    detail: string;
+    relatedInvoiceId?: string;
+    severity: 'low' | 'medium' | 'high' | string;
+    type: string;
+  }>;
+  reports: Report[];
+  journalEntries: JournalEntry[];
+  journalEntriesPreview?: JournalEntry[];
+  totalJournalEntries: number;
 }
 
-export interface GetAllAccountantWorkResponseDto {
-  message: string;
+export interface TaxPersistResponse {
+  businessId: string;
+  success: boolean;
+  year: number;
+}
+
+export interface TaxBreakdown {
+  corporate_tax_due: number;
+  corporate_tax_rate: number;
+  due_date: string;
+  filing_period: string;
+  taxable_income: number;
+  total_tax_liability: number;
+  vat_exempt: number;
+  vat_reduced_13: number;
+  vat_reduced_7: number;
+  vat_standard_19: number;
+  vat_total: number;
+  withholding_tax: number;
+}
+
+export interface TaxResultsResponse {
+  businessId: string;
+  year: number;
+  analysis: Record<string, unknown>;
+  llmRecommendations: string[];
+  llmSummary: string;
+  createdAt: string;
+  lastUpdatedAt: string;
+  taxBreakdown: TaxBreakdown;
+}
+
+export interface ServiceHealthChecks {
+  model: boolean;
+  mongodb: boolean;
+  redis: boolean;
+}
+
+export interface ServiceModelInfo {
+  modelPath: boolean | string;
+  name: string;
+  ready: boolean;
+  usingTensorflow: boolean;
+}
+
+export interface ServiceHealthResponse {
+  checks: ServiceHealthChecks;
+  modelInfo: ServiceModelInfo;
+  service: string;
+  status: string;
   timestamp: string;
-  work: {
-    businessId: string;
-    databaseName?: string;
-    summary?: {
-      totalAccountingPeriods?: number;
-      completed?: number;
-      pending?: number;
-      processing?: number;
-      failed?: number;
-      totalJournalEntriesGenerated?: number;
-      totalRevenueProcessed?: number;
-    };
-    accountingPeriods?: AccountantWorkPeriodDto[];
-  };
+  version: string;
+  workerPid: number;
 }
 
-export interface MonthlyTaxDetailDto {
-  month: number;
-  period: string;
-  vatStandard19?: number;
-  vatReduced13?: number;
-  vatReduced7?: number;
-  vatTotal?: number;
-  taxableIncome?: number;
-  corporateTaxDue?: number;
-  withholdingTax?: number;
-  totalTaxLiability?: number;
-  dueDate?: string;
+export interface CreateAccountingJobResponseDto extends BaseResponse {
+  job: CreateJobResponse;
 }
 
-export interface TaxCalendarItemDto {
-  period: string;
-  dueDate?: string;
-  description?: string;
+export interface ListAccountingJobsResponseDto extends BaseResponse {
+  jobs: JobSummary[];
+  total: number;
 }
 
-export interface TunisianTaxSummaryResponseDto {
-  message: string;
-  timestamp: string;
-  taxes: {
-    businessId: string;
-    businessName?: string;
-    year: number;
-    currency?: string;
-    summary?: {
-      annualVatTotal?: number;
-      annualCorporateTax?: number;
-      annualWithholdingTax?: number;
-      totalTaxLiability?: number;
-    };
-    vatBreakdown?: {
-      standardRate19Percent?: number;
-      reducedRate13Percent?: number;
-      reducedRate7Percent?: number;
-    };
-    monthlyDetails?: MonthlyTaxDetailDto[];
-    taxCalendar?: TaxCalendarItemDto[];
-    notes?: string[];
-  };
+export interface GetJobStatusResponseDto extends BaseResponse {
+  job?: CreateJobResponse;
+  results?: AccountingResults;
 }
 
-export type TaxSummaryDto = TunisianTaxSummaryResponseDto['taxes']['summary'];
-
-export interface CalculateTaxResponseDto {
-  message: string;
-  timestamp: string;
-  result: {
-    businessId: string;
-    businessName?: string;
-    year: number;
-    summary: TaxSummaryDto | undefined;
-    message?: string;
-  };
+export interface GetJobResultsResponseDto extends BaseResponse {
+  results: AccountingResults;
 }
 
-export interface QuickHealthResponseDto {
-  status: 'healthy' | 'ready' | string;
-}
-
-export interface ReadinessChecks {
-  mongodb?: boolean;
-  redis?: boolean;
-  model?: boolean;
-  [key: string]: boolean | undefined;
-}
-
-export interface ModelInfoDto {
-  name?: string;
-  ready?: boolean;
-  [key: string]: unknown;
-}
-
-export interface ReadinessResponseDto {
-  status: 'ready' | 'not_ready' | string;
-  checks?: ReadinessChecks;
-  worker_pid?: number;
-  model_info?: ModelInfoDto;
-  timestamp?: string;
-  [key: string]: unknown;
-}
-
-export type AccountantHealthResponseDto =
-  | QuickHealthResponseDto
-  | ReadinessResponseDto;
+export type TunisianTaxSummaryResponseDto = TaxResultsResponse;
+export interface CalculateTaxResponseDto
+  extends BaseResponse, TaxPersistResponse {}
+export type AccountantHealthResponseDto = ServiceHealthResponse;

--- a/types/services/accountantSchemas.ts
+++ b/types/services/accountantSchemas.ts
@@ -1,7 +1,10 @@
 import { z } from 'zod';
 
-const DateSchema = z.iso
-  .date({ error: 'Invalid ISO date' })
+const DateSchema = z
+  .string()
+  .refine((val) => !Number.isNaN(Date.parse(val)), {
+    message: 'Invalid ISO datetime',
+  })
   .transform((val) => new Date(val));
 
 export const CreateAccountingJobSchema = z
@@ -13,11 +16,25 @@ export const CreateAccountingJobSchema = z
   .refine((data) => data.periodEnd.getTime() >= data.periodStart.getTime(), {
     message: 'Period end must be after or equal to period start',
     path: ['periodEnd'],
-  });
+  })
+  .refine(
+    (data) =>
+      data.periodEnd.getTime() - data.periodStart.getTime() <=
+      365 * 24 * 60 * 60 * 1000,
+    {
+      message: 'Period length must not exceed 365 days',
+      path: ['periodEnd'],
+    }
+  );
+
+export type CreateAccountingJobRequest = z.infer<
+  typeof CreateAccountingJobSchema
+>;
 
 export const ListAccountingJobsQuerySchema = z.object({
-  businessId: z.string().optional(),
-  limit: z.coerce.number().int().positive().optional(),
+  businessId: z.string().min(1, 'Business ID is required'),
+  status: z.enum(['pending', 'processing', 'completed', 'failed']).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
 });
 
 export const GetJobStatusParamsSchema = z.object({
@@ -25,20 +42,7 @@ export const GetJobStatusParamsSchema = z.object({
 });
 
 export const GetJobStatusQuerySchema = z.object({
-  businessId: z.string().optional(),
-});
-
-export const CancelJobParamsSchema = z.object({
-  taskId: z.string().min(1, 'Task ID is required'),
-});
-
-export const CancelJobQuerySchema = z.object({
-  businessId: z.string().optional(),
-});
-
-export const GetAccountingHistoryQuerySchema = z.object({
-  businessId: z.string().optional(),
-  limit: z.coerce.number().int().positive().optional(),
+  businessId: z.string().min(1, 'Business ID is required'),
 });
 
 export const GetJobResultsParamsSchema = z.object({
@@ -46,38 +50,23 @@ export const GetJobResultsParamsSchema = z.object({
 });
 
 export const GetJobResultsQuerySchema = z.object({
-  businessId: z.string().optional(),
+  businessId: z.string().min(1, 'Business ID is required'),
 });
 
-export const GetAllAccountantWorkQuerySchema = z
-  .object({
-    businessId: z.string().optional(),
-    startDate: DateSchema.optional(),
-    endDate: DateSchema.optional(),
-    status: z.string().optional(),
-  })
-  .refine(
-    (data) =>
-      !data.startDate ||
-      !data.endDate ||
-      data.endDate.getTime() >= data.startDate.getTime(),
-    {
-      message: 'End date must be after or equal to start date',
-      path: ['endDate'],
-    }
-  );
-
 export const GetTaxesQuerySchema = z.object({
-  businessId: z.string().optional(),
-  year: z.coerce.number().int().gte(2000).lte(2100).optional(),
+  businessId: z.string().min(1, 'Business ID is required'),
+  year: z.coerce.number().int().gte(2000).lte(2100),
 });
 
 export const CalculateTaxesQuerySchema = z.object({
-  businessId: z.string().optional(),
-  year: z.coerce.number().int().gte(2000).lte(2100).optional(),
+  businessId: z.string().min(1, 'Business ID is required'),
+  year: z.coerce.number().int().gte(2000).lte(2100),
 });
 
 export type CreateAccountingJobInput = z.input<
+  typeof CreateAccountingJobSchema
+>;
+export type CreateAccountingJobFormInput = z.input<
   typeof CreateAccountingJobSchema
 >;
 export type ListAccountingJobsQuery = z.infer<
@@ -87,13 +76,5 @@ export type GetJobStatusParams = z.infer<typeof GetJobStatusParamsSchema>;
 export type GetJobStatusQuery = z.infer<typeof GetJobStatusQuerySchema>;
 export type GetJobResultsParams = z.infer<typeof GetJobResultsParamsSchema>;
 export type GetJobResultsQuery = z.infer<typeof GetJobResultsQuerySchema>;
-export type CancelJobParams = z.infer<typeof CancelJobParamsSchema>;
-export type CancelJobQuery = z.infer<typeof CancelJobQuerySchema>;
-export type GetAccountingHistoryQuery = z.infer<
-  typeof GetAccountingHistoryQuerySchema
->;
-export type GetAllAccountantWorkQuery = z.infer<
-  typeof GetAllAccountantWorkQuerySchema
->;
 export type GetTaxesQuery = z.infer<typeof GetTaxesQuerySchema>;
 export type CalculateTaxesQuery = z.infer<typeof CalculateTaxesQuerySchema>;

--- a/types/services/sharedTypes.ts
+++ b/types/services/sharedTypes.ts
@@ -2,10 +2,3 @@ export interface BaseResponse {
   message: string;
   timestamp?: string;
 }
-
-// Generic API wrapper for endpoints that return `{ success, data, message? }`.
-export interface ApiResponse<T = unknown> {
-  success: boolean;
-  data: T;
-  message?: string;
-}


### PR DESCRIPTION
### TL;DR

Aligns the AI Accountant service layer with the actual backend API contract, removing endpoints and features that no longer exist and reshaping types to match real response payloads.

### What changed?

- Removed job cancellation support entirely — the cancel endpoint, mutation, cancel button, and related dictionary keys (`jobCancelled`, `cancelJobError`, `cancelled` status) have all been dropped.
- Removed the `getJobStatus`, `getHistory`, and `getWork` service methods, along with their associated types and schemas.
- `GET /accountant/jobs/:taskId` now serves as the single endpoint for both job status and results via `getJobResults`.
- Tax endpoints (`GET` and `POST`) now include the year as a path parameter (`/accountant/taxes/{year}`) and require both `businessId` and `year` to be present.
- The health check now uses a single authenticated request instead of falling back between a readiness probe and a quick health endpoint.
- `TunisianTaxSummaryResponseDto` is reshaped to match the actual `TaxResultsResponse` payload, with tax figures sourced from `taxBreakdown` fields (e.g. `corporate_tax_due`, `vat_total`, `withholding_tax`) instead of the old `summary` object.
- `TaxSummaryView` now reads from `taxBreakdown` directly and derives VAT breakdown from snake_case fields.
- `GetJobResultsResponseDto` and related response types are rebuilt from real sample payloads, replacing the previous speculative structure.
- Anomaly descriptions in `JobResultsView` now fall back to the `detail` field the backend actually sends, with `description` as a secondary fallback.
- The jobs table removes the progress bar column and replaces the started-at timestamp with a reports-generated count.
- The `DateSchema` in Zod schemas is updated to use a plain string refinement instead of `z.iso.date`, and a 365-day maximum period length validation is added to `CreateAccountingJobSchema`.
- `businessId` is now required (not optional) across all query schemas.
- The `ApiResponse` generic wrapper type is removed from shared types.

### Why make this change?

The previous service layer was built against an assumed API contract that diverged from what the backend actually exposes. This caused broken requests, missing data, and dead code paths. This change brings the frontend into sync with the real API, removes unsupported operations, and ensures type definitions reflect actual response shapes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clickable "Launched at" column with sort indicators and job ID visible
  * Full journal entries table shown when available

* **Improvements**
  * Jobs table: completion date, pluralized report counts, removed progress/started-at/cancel UI for non-completed jobs
  * Tax summary uses backend breakdown and fixed TND formatting
  * Reports list filters to meaningful entries
  * Stricter input validation for business/year and simplified health checks

* **Removed Features**
  * Job cancellation, history and work flows removed

* **Translations**
  * Job-related labels updated; status now includes “failed” and removes “cancelled”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->